### PR TITLE
Finish implementation of speaker editor GUI

### DIFF
--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -1,3 +1,4 @@
+use metres::Metres;
 use std;
 use std::path::Path;
 use toml;
@@ -17,16 +18,23 @@ pub struct Config {
     pub interaction_log_limit: usize,
     #[serde(default = "default::floorplan_pixels_per_metre")]
     pub floorplan_pixels_per_metre: f64,
+    #[serde(default = "default::min_speaker_radius_metres")]
+    pub min_speaker_radius_metres: Metres,
+    #[serde(default = "default::max_speaker_radius_metres")]
+    pub max_speaker_radius_metres: Metres,
 }
 
 // Fallback parameters in the case that they are missing from the file or invalid.
 pub mod default {
+    use metres::Metres;
     pub fn window_width() -> u32 { 1280 }
     pub fn window_height() -> u32 { 720 }
     pub fn osc_input_port() -> u16 { 9001 }
     pub fn osc_log_limit() -> usize { 50 }
     pub fn interaction_log_limit() -> usize { 50 }
     pub fn floorplan_pixels_per_metre() -> f64 { 148.0 }
+    pub fn min_speaker_radius_metres() -> Metres { Metres(0.25) }
+    pub fn max_speaker_radius_metres() -> Metres { Metres(1.0) }
 }
 
 /// Load the `Config` from the toml file at the given path.

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -52,7 +52,7 @@ pub fn run() {
 
     // Create the audio requester which transfers audio from the audio engine to the audio backend.
     const FRAMES_PER_BUFFER: usize = 64;
-    let audio_requester = audio::Requester::new(audio_msg_tx, FRAMES_PER_BUFFER);
+    let audio_requester = audio::Requester::new(audio_msg_tx.clone(), FRAMES_PER_BUFFER);
 
     // Run the CPAL audio backend for interfacing with the audio device.
     const SAMPLE_HZ: f64 = 44_100.0;
@@ -66,7 +66,7 @@ pub fn run() {
     // `gui_render_rx` channel.
     let proxy = events_loop.create_proxy();
     let (mut renderer, image_map, gui_msg_tx, gui_render_rx) =
-        gui::spawn(&assets, config, &display, proxy, osc_msg_rx, interaction_gui_rx);
+        gui::spawn(&assets, config, &display, proxy, osc_msg_rx, interaction_gui_rx, audio_msg_tx);
 
     // Run the event loop.
     let mut closed = false;

--- a/src/lib/metres.rs
+++ b/src/lib/metres.rs
@@ -2,12 +2,14 @@ custom_derive! {
     /// Used for describing locations throughout the installation.
     ///
     /// Using this GUI agnostic measurement greatly simplifies positioning and makes it easier
-    #[derive(Copy, Clone, Debug, Default, PartialEq, PartialOrd, NewtypeFrom,
+    #[derive(Copy, Clone, Debug, Default, PartialEq, PartialOrd,
+             NewtypeFrom,
              NewtypeAdd, NewtypeSub, NewtypeMul, NewtypeMul(f64), NewtypeDiv, NewtypeDiv(f64),
              NewtypeAddAssign, NewtypeSubAssign, NewtypeMulAssign, NewtypeDivAssign,
              NewtypeMulAssign(f64), NewtypeDivAssign(f64),
              NewtypeRem, NewtypeRemAssign,
              NewtypeNeg)]
+    #[derive(Serialize, Deserialize)]
     pub struct Metres(pub f64);
 }
 


### PR DESCRIPTION
This adds the ability to assign a unique channel per speaker and to drag
speakers to positions (in metres) within the space in a thread-safe
manner so that positions may be used for the distance to amplitude
translation function on the audio thread.

Closes #5