### PR TITLE
Use max number of output channels if target number is not available

### DIFF
--- a/src/lib/audio/mod.rs
+++ b/src/lib/audio/mod.rs
@@ -81,7 +81,7 @@ pub fn render(mut model: Model, mut buffer: Buffer) -> (Model, Buffer) {
         // For each sound, request `buffer.len()` number of frames and sum them onto the
         // relevant output channels.
         for (&_sound_id, sound) in sounds {
-            let num_samples = buffer.len() * sound.channels;
+            let num_samples = buffer.len_frames() * sound.channels;
 
             // Clear the unmixed samples, ready to collect the new ones.
             unmixed_samples.clear();

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -61,12 +61,12 @@ fn model(app: &App) -> Model {
 
     // Get the default device and attempt to set it up with the target number of channels.
     let device = app.audio.default_output_device().unwrap();
-    let supported_channels = device
+    let mut supported_channels = device
         .supported_formats()
         .unwrap()
-        .next()
-        .map(|format| format.channels.len())
-        .unwrap();
+        .map(|fmt| fmt.channels.len());
+    let first_supported_channels = supported_channels.next().unwrap();
+    let supported_channels = supported_channels.fold(first_supported_channels, std::cmp::max);
 
     // Initialise the audio model and create the stream.
     let audio_model = audio::Model::new();


### PR DESCRIPTION
This fixes an issue where an error would occur if the target number of channels was not available. We now fall back to the max number of channels  available on the hardware if the target is not available.