### PR TITLE
Update speaker editor to allow for installation assignments

### DIFF
--- a/assets/installations.json
+++ b/assets/installations.json
@@ -1,48 +1,4 @@
 {
-  "EnergeticVibrationsProjectionMapping": {
-    "0": {
-      "socket": "127.0.0.1:9002",
-      "osc_addr": "enpm/0"
-    },
-    "1": {
-      "socket": "127.0.0.1:9002",
-      "osc_addr": "enpm/1"
-    },
-    "2": {
-      "socket": "127.0.0.1:9002",
-      "osc_addr": "enpm/2"
-    }
-  },
-  "EnergeticVibrationsAudioVisualiser": {
-    "0": {
-      "socket": "127.0.0.1:9002",
-      "osc_addr": "enav/0"
-    }
-  },
-  "Cacophony": {
-    "0": {
-      "socket": "127.0.0.1:9002",
-      "osc_addr": "caco/0"
-    }
-  },
-  "RipplesInSpacetime": {
-    "1": {
-      "socket": "127.0.0.1:9002",
-      "osc_addr": "ripp/1"
-    },
-    "3": {
-      "socket": "127.0.0.1:9002",
-      "osc_addr": "ripp/3"
-    },
-    "2": {
-      "socket": "127.0.0.1:9002",
-      "osc_addr": "ripp/2"
-    },
-    "0": {
-      "socket": "127.0.0.1:9002",
-      "osc_addr": "ripp/0"
-    }
-  },
   "WrappedInSpectrum": {
     "1": {
       "socket": "127.0.0.1:9002",
@@ -53,16 +9,60 @@
       "osc_addr": "wrap/0"
     }
   },
-  "WavesAtWork": {
+  "Cacophony": {
     "0": {
       "socket": "127.0.0.1:9002",
-      "osc_addr": "wave/0"
+      "osc_addr": "caco/0"
     }
   },
   "TurbulentEncounters": {
     "0": {
       "socket": "127.0.0.1:9002",
       "osc_addr": "turb/0"
+    }
+  },
+  "EnergeticVibrationsProjectionMapping": {
+    "0": {
+      "socket": "127.0.0.1:9002",
+      "osc_addr": "enpm/0"
+    },
+    "2": {
+      "socket": "127.0.0.1:9002",
+      "osc_addr": "enpm/2"
+    },
+    "1": {
+      "socket": "127.0.0.1:9002",
+      "osc_addr": "enpm/1"
+    }
+  },
+  "RipplesInSpacetime": {
+    "3": {
+      "socket": "127.0.0.1:9002",
+      "osc_addr": "ripp/3"
+    },
+    "0": {
+      "socket": "127.0.0.1:9002",
+      "osc_addr": "ripp/0"
+    },
+    "1": {
+      "socket": "127.0.0.1:9002",
+      "osc_addr": "ripp/1"
+    },
+    "2": {
+      "socket": "127.0.0.1:9002",
+      "osc_addr": "ripp/2"
+    }
+  },
+  "WavesAtWork": {
+    "0": {
+      "socket": "127.0.0.1:9002",
+      "osc_addr": "wave/0"
+    }
+  },
+  "EnergeticVibrationsAudioVisualiser": {
+    "0": {
+      "socket": "127.0.0.1:9002",
+      "osc_addr": "enav/0"
     }
   }
 }

--- a/assets/speakers.json
+++ b/assets/speakers.json
@@ -7,7 +7,10 @@
           "x": 18.43515199768545,
           "y": 30.083772895727085
         },
-        "channel": 0
+        "channel": 0,
+        "installations": [
+          "Cacophony"
+        ]
       },
       "name": "S_ch1",
       "id": 0
@@ -18,7 +21,10 @@
           "x": 22.569953163477444,
           "y": 30.105695401800305
         },
-        "channel": 1
+        "channel": 1,
+        "installations": [
+          "Cacophony"
+        ]
       },
       "name": "S_ch2",
       "id": 1
@@ -29,7 +35,10 @@
           "x": 15.907828217771624,
           "y": 27.683100271911113
         },
-        "channel": 2
+        "channel": 2,
+        "installations": [
+          "Cacophony"
+        ]
       },
       "name": "S_ch3",
       "id": 2
@@ -40,7 +49,10 @@
           "x": 25.44432905384432,
           "y": 27.47104908095091
         },
-        "channel": 3
+        "channel": 3,
+        "installations": [
+          "Cacophony"
+        ]
       },
       "name": "S_ch4",
       "id": 3
@@ -51,7 +63,10 @@
           "x": 15.612026208874444,
           "y": 22.457726798498844
         },
-        "channel": 4
+        "channel": 4,
+        "installations": [
+          "Cacophony"
+        ]
       },
       "name": "S_ch5",
       "id": 4
@@ -62,7 +77,10 @@
           "x": 25.457377927325333,
           "y": 22.467120628008684
         },
-        "channel": 5
+        "channel": 5,
+        "installations": [
+          "Cacophony"
+        ]
       },
       "name": "S_ch6",
       "id": 5
@@ -73,7 +91,8 @@
           "x": 18.510194203151344,
           "y": 19.750314116379874
         },
-        "channel": 6
+        "channel": 6,
+        "installations": []
       },
       "name": "S_ch7",
       "id": 6
@@ -84,7 +103,8 @@
           "x": 22.45672076753277,
           "y": 19.68808640969627
         },
-        "channel": 7
+        "channel": 7,
+        "installations": []
       },
       "name": "S_ch8",
       "id": 7

--- a/src/lib/audio/speaker.rs
+++ b/src/lib/audio/speaker.rs
@@ -1,5 +1,7 @@
+use installation::Installation;
 use metres::Metres;
 use nannou::math::Point2;
+use std::collections::HashSet;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub struct Id(pub u64);
@@ -13,4 +15,7 @@ pub struct Speaker {
     pub point: Point2<Metres>,
     // The channel on which the output is rendered.
     pub channel: usize,
+    // Installations assigned to this speaker.
+    #[serde(default)]
+    pub installations: HashSet<Installation>,
 }

--- a/src/lib/gui/mod.rs
+++ b/src/lib/gui/mod.rs
@@ -793,6 +793,11 @@ widget_ids! {
         speaker_editor_selected_name,
         speaker_editor_selected_channel,
         speaker_editor_selected_position,
+        speaker_editor_selected_installations_canvas,
+        speaker_editor_selected_installations_text,
+        speaker_editor_selected_installations_ddl,
+        speaker_editor_selected_installations_list,
+        speaker_editor_selected_installations_remove,
         // Audio Sources.
         source_editor,
         source_editor_no_sources,

--- a/src/lib/gui/speaker_editor.rs
+++ b/src/lib/gui/speaker_editor.rs
@@ -1,6 +1,7 @@
 use audio;
 use gui::{collapsible_area, Gui};
 use gui::{ITEM_HEIGHT, SMALL_FONT_SIZE, DARK_A};
+use installation::{self, Installation};
 use nannou::ui;
 use nannou::ui::prelude::*;
 use serde_json;
@@ -63,7 +64,9 @@ pub fn set(last_area_id: widget::Id, gui: &mut Gui) -> widget::Id {
     const LIST_HEIGHT: Scalar = 140.0;
     const PAD: Scalar = 6.0;
     const TEXT_PAD: Scalar = 20.0;
-    const SELECTED_CANVAS_H: Scalar = ITEM_HEIGHT * 2.0 + PAD * 3.0;
+    const INSTALLATION_LIST_H: Scalar = ITEM_HEIGHT * 3.0;
+    const INSTALLATIONS_CANVAS_H: Scalar = PAD + ITEM_HEIGHT * 2.0 + PAD + INSTALLATION_LIST_H + PAD;
+    const SELECTED_CANVAS_H: Scalar = ITEM_HEIGHT * 2.0 + PAD * 4.0 + INSTALLATIONS_CANVAS_H;
     let speaker_editor_canvas_h = LIST_HEIGHT + ITEM_HEIGHT + SELECTED_CANVAS_H;
 
     let (area, event) = collapsible_area(is_open, "Speaker Editor", gui.ids.side_menu)
@@ -74,266 +77,388 @@ pub fn set(last_area_id: widget::Id, gui: &mut Gui) -> widget::Id {
         gui.state.speaker_editor.is_open = event.is_open();
     }
 
-    let last_area_id = if let Some(area) = area {
-        // The canvas on which the log will be placed.
-        let canvas = widget::Canvas::new()
-            .scroll_kids()
-            .pad(0.0)
-            .h(speaker_editor_canvas_h);
-        area.set(canvas, gui);
+    // Only continue if the collapsible area is open.
+    let area = match area {
+        None => return gui.ids.speaker_editor,
+        Some(area) => area,
+    };
 
-        // If there are no speakers, display a message saying how to add some.
-        if gui.state.speaker_editor.speakers.is_empty() {
-            widget::Text::new("Add some speaker outputs with the `+` button")
-                .padded_w_of(area.id, TEXT_PAD)
-                .mid_top_with_margin_on(area.id, TEXT_PAD)
-                .font_size(SMALL_FONT_SIZE)
-                .center_justify()
-                .set(gui.ids.speaker_editor_no_speakers, gui);
+    // The canvas on which the log will be placed.
+    let canvas = widget::Canvas::new()
+        .scroll_kids()
+        .pad(0.0)
+        .h(speaker_editor_canvas_h);
+    area.set(canvas, gui);
 
-        // Otherwise display the speaker list.
-        } else {
-            let num_items = gui.state.speaker_editor.speakers.len();
-            let (mut list_events, scrollbar) = widget::ListSelect::single(num_items)
-                .item_size(ITEM_HEIGHT)
-                .h(LIST_HEIGHT)
-                .align_middle_x_of(area.id)
-                .align_top_of(area.id)
-                .scrollbar_next_to()
-                .scrollbar_color(color::LIGHT_CHARCOAL)
-                .set(gui.ids.speaker_editor_list, gui);
+    // If there are no speakers, display a message saying how to add some.
+    if gui.state.speaker_editor.speakers.is_empty() {
+        widget::Text::new("Add some speaker outputs with the `+` button")
+            .padded_w_of(area.id, TEXT_PAD)
+            .mid_top_with_margin_on(area.id, TEXT_PAD)
+            .font_size(SMALL_FONT_SIZE)
+            .center_justify()
+            .set(gui.ids.speaker_editor_no_speakers, gui);
 
-            // If a speaker was removed, process it after the whole list is instantiated to avoid
-            // invalid indices.
-            let mut maybe_remove_index = None;
+    // Otherwise display the speaker list.
+    } else {
+        let num_items = gui.state.speaker_editor.speakers.len();
+        let (mut list_events, scrollbar) = widget::ListSelect::single(num_items)
+            .item_size(ITEM_HEIGHT)
+            .h(LIST_HEIGHT)
+            .align_middle_x_of(area.id)
+            .align_top_of(area.id)
+            .scrollbar_next_to()
+            .scrollbar_color(color::LIGHT_CHARCOAL)
+            .set(gui.ids.speaker_editor_list, gui);
 
-            while let Some(event) = list_events.next(gui, |i| gui.state.speaker_editor.selected == Some(i)) {
-                use self::ui::widget::list_select::Event;
-                match event {
+        // If a speaker was removed, process it after the whole list is instantiated to avoid
+        // invalid indices.
+        let mut maybe_remove_index = None;
 
-                    // Instantiate a button for each speaker.
-                    Event::Item(item) => {
-                        let selected = gui.state.speaker_editor.selected == Some(item.i);
-                        let label = {
-                            let speaker = &gui.state.speaker_editor.speakers[item.i];
-                            let channel = speaker.audio.channel;
-                            let position = speaker.audio.point;
-                            let label = format!("{} - CH {} - ({}mx, {}my)",
-                                                speaker.name, channel,
-                                                (position.x.0 * 100.0).trunc() / 100.0,
-                                                (position.y.0 * 100.0).trunc() / 100.0);
-                            label
-                        };
+        while let Some(event) = list_events.next(gui, |i| gui.state.speaker_editor.selected == Some(i)) {
+            use self::ui::widget::list_select::Event;
+            match event {
 
-                        // Blue if selected, gray otherwise.
-                        let color = if selected { color::BLUE } else { color::CHARCOAL };
+                // Instantiate a button for each speaker.
+                Event::Item(item) => {
+                    let selected = gui.state.speaker_editor.selected == Some(item.i);
+                    let label = {
+                        let speaker = &gui.state.speaker_editor.speakers[item.i];
+                        let channel = speaker.audio.channel;
+                        let position = speaker.audio.point;
+                        let label = format!("{} - CH {} - ({}mx, {}my)",
+                                            speaker.name, channel,
+                                            (position.x.0 * 100.0).trunc() / 100.0,
+                                            (position.y.0 * 100.0).trunc() / 100.0);
+                        label
+                    };
 
-                        // Use `Button`s for the selectable items.
-                        let button = widget::Button::new()
-                            .label(&label)
-                            .label_font_size(SMALL_FONT_SIZE)
-                            .label_x(position::Relative::Place(position::Place::Start(Some(10.0))))
-                            .color(color);
-                        item.set(button, gui);
+                    // Blue if selected, gray otherwise.
+                    let color = if selected { color::BLUE } else { color::CHARCOAL };
 
-                        // If the button or any of its children are capturing the mouse, display
-                        // the `remove` button.
-                        let show_remove_button = gui.global_input().current.widget_capturing_mouse
-                            .map(|id| {
-                                id == item.widget_id ||
-                                gui.widget_graph()
-                                    .does_recursive_depth_edge_exist(item.widget_id, id)
-                            })
-                            .unwrap_or(false);
+                    // Use `Button`s for the selectable items.
+                    let button = widget::Button::new()
+                        .label(&label)
+                        .label_font_size(SMALL_FONT_SIZE)
+                        .label_x(position::Relative::Place(position::Place::Start(Some(10.0))))
+                        .color(color);
+                    item.set(button, gui);
 
-                        if !show_remove_button {
-                            continue;
-                        }
+                    // If the button or any of its children are capturing the mouse, display
+                    // the `remove` button.
+                    let show_remove_button = gui.global_input().current.widget_capturing_mouse
+                        .map(|id| {
+                            id == item.widget_id ||
+                            gui.widget_graph()
+                                .does_recursive_depth_edge_exist(item.widget_id, id)
+                        })
+                        .unwrap_or(false);
 
-                        if widget::Button::new()
-                            .label("X")
-                            .label_font_size(SMALL_FONT_SIZE)
-                            .color(color::DARK_RED.alpha(0.5))
-                            .w_h(ITEM_HEIGHT, ITEM_HEIGHT)
-                            .align_right_of(item.widget_id)
-                            .align_middle_y_of(item.widget_id)
-                            .parent(item.widget_id)
-                            .set(gui.ids.speaker_editor_remove, gui)
-                            .was_clicked()
-                        {
-                            maybe_remove_index = Some(item.i);
-                        }
-                    },
-
-                    // Update the selected speaker.
-                    Event::Selection(idx) => gui.state.speaker_editor.selected = Some(idx),
-
-                    _ => (),
-                }
-            }
-
-            // The scrollbar for the list.
-            if let Some(s) = scrollbar { s.set(gui); }
-
-            // Remove a speaker if necessary.
-            if let Some(i) = maybe_remove_index {
-                if Some(i) == gui.state.speaker_editor.selected {
-                    gui.state.speaker_editor.selected = None;
-                }
-                let speaker = gui.state.speaker_editor.speakers.remove(i);
-                let speaker_id = speaker.id;
-                gui.channels.audio.send(move |audio| {
-                    audio.remove_speaker(speaker_id);
-                }).ok();
-            }
-        }
-
-        // Only display the `add_speaker` button if there are less than `max` num channels.
-        let show_add_button = gui.state.speaker_editor.speakers.len() < audio::MAX_CHANNELS;
-
-        if show_add_button {
-            let plus_size = (ITEM_HEIGHT * 0.66) as FontSize;
-            if widget::Button::new()
-                .color(DARK_A)
-                .label("+")
-                .label_font_size(plus_size)
-                .align_middle_x_of(area.id)
-                .mid_top_with_margin_on(area.id, LIST_HEIGHT)
-                .w_of(area.id)
-                .parent(area.id)
-                .set(gui.ids.speaker_editor_add, gui)
-                .was_clicked()
-            {
-                let id = gui.state.speaker_editor.next_id;
-                let name = format!("S{}", id.0);
-                let channel = {
-                    // Search for the next available channel starting from 0.
-                    //
-                    // Note: This is a super naiive way of searching however there should never
-                    // be enough speakers to make it a problem.
-                    let mut channel = 0;
-                    'search: loop {
-                        for speaker in &gui.state.speaker_editor.speakers {
-                            if channel == speaker.audio.channel {
-                                channel += 1;
-                                continue 'search;
-                            }
-                        }
-                        break channel;
+                    if !show_remove_button {
+                        continue;
                     }
-                };
-                let audio = audio::Speaker {
-                    point: gui.state.camera.position,
-                    channel: channel,
-                };
 
-                let speaker = audio.clone();
-                gui.channels.audio.send(move |audio| {
-                    audio.insert_speaker(id, speaker);
-                }).ok();
+                    if widget::Button::new()
+                        .label("X")
+                        .label_font_size(SMALL_FONT_SIZE)
+                        .color(color::DARK_RED.alpha(0.5))
+                        .w_h(ITEM_HEIGHT, ITEM_HEIGHT)
+                        .align_right_of(item.widget_id)
+                        .align_middle_y_of(item.widget_id)
+                        .parent(item.widget_id)
+                        .set(gui.ids.speaker_editor_remove, gui)
+                        .was_clicked()
+                    {
+                        maybe_remove_index = Some(item.i);
+                    }
+                },
 
-                let speaker = Speaker { id, name, audio };
-                gui.state.speaker_editor.speakers.push(speaker);
-                gui.state.speaker_editor.next_id = audio::speaker::Id(id.0.wrapping_add(1));
-                gui.state.speaker_editor.selected = Some(gui.state.speaker_editor.speakers.len() - 1);
+                // Update the selected speaker.
+                Event::Selection(idx) => gui.state.speaker_editor.selected = Some(idx),
+
+                _ => (),
             }
         }
 
-        let area_rect = gui.rect_of(area.id).unwrap();
-        let start = area_rect.y.start;
-        let end = start + SELECTED_CANVAS_H;
-        let selected_canvas_y = ui::Range { start, end };
+        // The scrollbar for the list.
+        if let Some(s) = scrollbar { s.set(gui); }
 
-        widget::Canvas::new()
-            .pad(PAD)
-            .w_of(gui.ids.side_menu)
-            .h(SELECTED_CANVAS_H)
-            .y(selected_canvas_y.middle())
-            .align_middle_x_of(gui.ids.side_menu)
-            .set(gui.ids.speaker_editor_selected_canvas, gui);
-
-        // If a speaker is selected, display its info.
-        if let Some(i) = gui.state.speaker_editor.selected {
-            let Gui { ref mut state, ref mut ui, ref ids, .. } = *gui;
-            let SpeakerEditor { ref mut speakers, .. } = state.speaker_editor;
-
-            for event in widget::TextBox::new(&speakers[i].name)
-                .mid_top_of(ids.speaker_editor_selected_canvas)
-                .kid_area_w_of(ids.speaker_editor_selected_canvas)
-                .parent(gui.ids.speaker_editor_selected_canvas)
-                .h(ITEM_HEIGHT)
-                .color(DARK_A)
-                .font_size(SMALL_FONT_SIZE)
-                .set(ids.speaker_editor_selected_name, ui)
-            {
-                if let widget::text_box::Event::Update(string) = event {
-                    speakers[i].name = string;
-                }
+        // Remove a speaker if necessary.
+        if let Some(i) = maybe_remove_index {
+            if Some(i) == gui.state.speaker_editor.selected {
+                gui.state.speaker_editor.selected = None;
             }
+            let speaker = gui.state.speaker_editor.speakers.remove(i);
+            let speaker_id = speaker.id;
+            gui.channels.audio.send(move |audio| {
+                audio.remove_speaker(speaker_id);
+            }).ok();
+        }
+    }
 
-            let channel_vec: Vec<String> = (0..audio::MAX_CHANNELS)
-                .map(|ch| {
-                    speakers
-                        .iter()
-                        .enumerate()
-                        .find(|&(ix, s)| i != ix && s.audio.channel == ch)
-                        .map(|(_ix, s)| format!("CH {} (swap with {})", ch, &s.name))
-                        .unwrap_or_else(|| format!("CH {}", ch))
-                })
-                .collect();
-            let selected = speakers[i].audio.channel;
+    // Only display the `add_speaker` button if there are less than `max` num channels.
+    let show_add_button = gui.state.speaker_editor.speakers.len() < audio::MAX_CHANNELS;
 
-            for new_index in widget::DropDownList::new(&channel_vec, Some(selected))
-                .down_from(ids.speaker_editor_selected_name, PAD)
-                .align_middle_x_of(ids.side_menu)
-                .kid_area_w_of(ids.speaker_editor_selected_canvas)
-                .h(ITEM_HEIGHT)
-                .parent(ids.speaker_editor_selected_canvas)
-                .scrollbar_on_top()
-                .max_visible_items(5)
-                .color(DARK_A)
-                .border_color(color::LIGHT_CHARCOAL)
-                .label_font_size(SMALL_FONT_SIZE)
-                .set(ids.speaker_editor_selected_channel, ui)
-            {
-                speakers[i].audio.channel = new_index;
-                let id = speakers[i].id;
-                let speaker = speakers[i].audio.clone();
-                gui.channels.audio.send(move |audio| {
-                    audio.insert_speaker(id, speaker);
-                }).ok();
-
-                // If an existing speaker was assigned to `index`, swap it with the original
-                // selection.
-                let maybe_index = speakers.iter()
-                    .enumerate()
-                    .find(|&(ix, s)| i != ix && s.audio.channel == new_index)
-                    .map(|(ix, _)| ix);
-                if let Some(ix) = maybe_index {
-                    let speaker = &mut speakers[ix];
-                    speaker.audio.channel = selected;
-                    let id = speaker.id;
-                    let speaker = speaker.audio.clone();
-                    gui.channels.audio.send(move |audio| {
-                        audio.insert_speaker(id, speaker);
-                    }).ok();
+    if show_add_button {
+        let plus_size = (ITEM_HEIGHT * 0.66) as FontSize;
+        if widget::Button::new()
+            .color(DARK_A)
+            .label("+")
+            .label_font_size(plus_size)
+            .align_middle_x_of(area.id)
+            .mid_top_with_margin_on(area.id, LIST_HEIGHT)
+            .w_of(area.id)
+            .parent(area.id)
+            .set(gui.ids.speaker_editor_add, gui)
+            .was_clicked()
+        {
+            let id = gui.state.speaker_editor.next_id;
+            let name = format!("S{}", id.0);
+            let channel = {
+                // Search for the next available channel starting from 0.
+                //
+                // Note: This is a super naiive way of searching however there should never
+                // be enough speakers to make it a problem.
+                let mut channel = 0;
+                'search: loop {
+                    for speaker in &gui.state.speaker_editor.speakers {
+                        if channel == speaker.audio.channel {
+                            channel += 1;
+                            continue 'search;
+                        }
+                    }
+                    break channel;
                 }
-            }
+            };
+            let audio = audio::Speaker {
+                point: gui.state.camera.position,
+                channel: channel,
+                installations: Default::default(),
+            };
 
-        // Otherwise no speaker is selected.
-        } else {
+            let speaker = audio.clone();
+            gui.channels.audio.send(move |audio| {
+                audio.insert_speaker(id, speaker);
+            }).ok();
+
+            let speaker = Speaker { id, name, audio };
+            gui.state.speaker_editor.speakers.push(speaker);
+            gui.state.speaker_editor.next_id = audio::speaker::Id(id.0.wrapping_add(1));
+            gui.state.speaker_editor.selected = Some(gui.state.speaker_editor.speakers.len() - 1);
+        }
+    }
+
+    let area_rect = gui.rect_of(area.id).unwrap();
+    let start = area_rect.y.start;
+    let end = start + SELECTED_CANVAS_H;
+    let selected_canvas_y = ui::Range { start, end };
+
+    widget::Canvas::new()
+        .pad(PAD)
+        .w_of(gui.ids.side_menu)
+        .h(SELECTED_CANVAS_H)
+        .y(selected_canvas_y.middle())
+        .align_middle_x_of(gui.ids.side_menu)
+        .set(gui.ids.speaker_editor_selected_canvas, gui);
+
+    // If a speaker is selected, display its info.
+    let i = match gui.state.speaker_editor.selected {
+        None => {
+            // Otherwise no speaker is selected.
             widget::Text::new("No speaker selected")
                 .padded_w_of(area.id, TEXT_PAD)
                 .mid_top_with_margin_on(gui.ids.speaker_editor_selected_canvas, TEXT_PAD)
                 .font_size(SMALL_FONT_SIZE)
                 .center_justify()
                 .set(gui.ids.speaker_editor_selected_none, gui);
-        }
-
-        area.id
-    } else {
-        gui.ids.speaker_editor
+            return area.id;
+        },
+        Some(i) => i,
     };
 
-    last_area_id
+    let Gui { ref mut state, ref mut ui, ref ids, .. } = *gui;
+    let SpeakerEditor { ref mut speakers, .. } = state.speaker_editor;
+
+    // The name of the speaker.
+    for event in widget::TextBox::new(&speakers[i].name)
+        .mid_top_of(ids.speaker_editor_selected_canvas)
+        .kid_area_w_of(ids.speaker_editor_selected_canvas)
+        .parent(gui.ids.speaker_editor_selected_canvas)
+        .h(ITEM_HEIGHT)
+        .color(DARK_A)
+        .font_size(SMALL_FONT_SIZE)
+        .set(ids.speaker_editor_selected_name, ui)
+    {
+        if let widget::text_box::Event::Update(string) = event {
+            speakers[i].name = string;
+        }
+    }
+
+    let channel_vec: Vec<String> = (0..audio::MAX_CHANNELS)
+        .map(|ch| {
+            speakers
+                .iter()
+                .enumerate()
+                .find(|&(ix, s)| i != ix && s.audio.channel == ch)
+                .map(|(_ix, s)| format!("CH {} (swap with {})", ch, &s.name))
+                .unwrap_or_else(|| format!("CH {}", ch))
+        })
+        .collect();
+    let selected_channel = speakers[i].audio.channel;
+
+    // The drop down list for channel selection.
+    for new_index in widget::DropDownList::new(&channel_vec, Some(selected_channel))
+        .down_from(ids.speaker_editor_selected_name, PAD)
+        .align_middle_x_of(ids.side_menu)
+        .kid_area_w_of(ids.speaker_editor_selected_canvas)
+        .h(ITEM_HEIGHT)
+        .parent(ids.speaker_editor_selected_canvas)
+        .scrollbar_on_top()
+        .max_visible_items(5)
+        .color(DARK_A)
+        .border_color(color::LIGHT_CHARCOAL)
+        .label_font_size(SMALL_FONT_SIZE)
+        .set(ids.speaker_editor_selected_channel, ui)
+    {
+        speakers[i].audio.channel = new_index;
+        let id = speakers[i].id;
+        let speaker = speakers[i].audio.clone();
+        gui.channels.audio.send(move |audio| {
+            audio.insert_speaker(id, speaker);
+        }).ok();
+
+        // If an existing speaker was assigned to `index`, swap it with the original
+        // selection.
+        let maybe_index = speakers.iter()
+            .enumerate()
+            .find(|&(ix, s)| i != ix && s.audio.channel == new_index)
+            .map(|(ix, _)| ix);
+        if let Some(ix) = maybe_index {
+            let speaker = &mut speakers[ix];
+            speaker.audio.channel = selected_channel;
+            let id = speaker.id;
+            let speaker = speaker.audio.clone();
+            gui.channels.audio.send(move |audio| {
+                audio.insert_speaker(id, speaker);
+            }).ok();
+        }
+    }
+
+    // A canvas on which installation selection widgets are instantiated.
+    widget::Canvas::new()
+        .kid_area_w_of(ids.speaker_editor_selected_canvas)
+        .h(INSTALLATIONS_CANVAS_H)
+        .mid_bottom_of(ids.speaker_editor_selected_canvas)
+        .pad(PAD)
+        .color(color::CHARCOAL)
+        .set(ids.speaker_editor_selected_installations_canvas, ui);
+
+    // A header for the installations editing area.
+    widget::Text::new("Installations")
+        .top_left_of(ids.speaker_editor_selected_installations_canvas)
+        .font_size(SMALL_FONT_SIZE)
+        .set(ids.speaker_editor_selected_installations_text, ui);
+
+    // A dropdownlist for assigning installations to the speaker.
+    //
+    // Only show installations that aren't yet assigned.
+    let installations = installation::ALL
+        .iter()
+        .filter(|inst| !speakers[i].audio.installations.contains(inst))
+        .cloned()
+        .collect::<Vec<_>>();
+    let installation_strs = installations
+        .iter()
+        .map(Installation::display_str)
+        .collect::<Vec<_>>();
+    for index in widget::DropDownList::new(&installation_strs, None)
+        .align_middle_x_of(ids.speaker_editor_selected_installations_canvas)
+        .down_from(ids.speaker_editor_selected_installations_text, PAD * 2.0)
+        .h(ITEM_HEIGHT)
+        .kid_area_w_of(ids.speaker_editor_selected_installations_canvas)
+        .label("ADD INSTALLATION")
+        .label_font_size(SMALL_FONT_SIZE)
+        .set(ids.speaker_editor_selected_installations_ddl, ui)
+    {
+        let installation = installations[index];
+        let speaker = &mut speakers[i];
+        let speaker_id = speaker.id;
+        speaker.audio.installations.insert(installation);
+        gui.channels.audio.send(move |audio| {
+            audio.insert_speaker_installation(speaker_id, installation);
+        }).ok();
+    }
+
+    // A scrollable list showing each of the assigned installations.
+    let mut selected_installations = speakers[i].audio.installations
+        .iter()
+        .cloned()
+        .collect::<Vec<_>>();
+    selected_installations.sort_by(|a, b| a.display_str().cmp(b.display_str()));
+    let (mut items, scrollbar) = widget::List::flow_down(selected_installations.len())
+        .item_size(ITEM_HEIGHT)
+        .h(INSTALLATION_LIST_H)
+        .kid_area_w_of(ids.speaker_editor_selected_installations_canvas)
+        .align_middle_x_of(ids.speaker_editor_selected_installations_canvas)
+        .down_from(ids.speaker_editor_selected_installations_ddl, PAD)
+        .scrollbar_next_to()
+        .scrollbar_color(color::LIGHT_CHARCOAL)
+        .set(ids.speaker_editor_selected_installations_list, ui);
+    let mut maybe_remove_index = None;
+    while let Some(item) = items.next(ui) {
+        let inst = selected_installations[item.i];
+        let label = inst.display_str();
+
+        // Use `Button`s for the selectable items.
+        let button = widget::Button::new()
+            .label(&label)
+            .label_font_size(SMALL_FONT_SIZE)
+            .label_x(position::Relative::Place(position::Place::Start(Some(10.0))));
+        item.set(button, ui);
+
+        // If the button or any of its children are capturing the mouse, display
+        // the `remove` button.
+        let show_remove_button = ui.global_input().current.widget_capturing_mouse
+            .map(|id| {
+                id == item.widget_id ||
+                ui.widget_graph()
+                    .does_recursive_depth_edge_exist(item.widget_id, id)
+            })
+            .unwrap_or(false);
+
+        if !show_remove_button {
+            continue;
+        }
+
+        if widget::Button::new()
+            .label("X")
+            .label_font_size(SMALL_FONT_SIZE)
+            .color(color::DARK_RED.alpha(0.5))
+            .w_h(ITEM_HEIGHT, ITEM_HEIGHT)
+            .align_right_of(item.widget_id)
+            .align_middle_y_of(item.widget_id)
+            .parent(item.widget_id)
+            .set(gui.ids.speaker_editor_selected_installations_remove, ui)
+            .was_clicked()
+        {
+            maybe_remove_index = Some(item.i);
+        }
+    }
+
+    // The scrollbar for the list.
+    if let Some(scrollbar) = scrollbar {
+        scrollbar.set(ui);
+    }
+
+    // If some installation was clicked for removal, remove it.
+    if let Some(inst) = maybe_remove_index.map(|i| selected_installations[i]) {
+        let speaker = &mut speakers[i];
+        let speaker_id = speaker.id;
+        speaker.audio.installations.remove(&inst);
+        gui.channels.audio.send(move |audio| {
+            audio.remove_speaker_installation(speaker_id, &inst);
+        }).ok();
+    }
+
+    area.id
 }


### PR DESCRIPTION
This ensures speaker audio data is only sent over OSC to the relevant
computers within each installation.

This will also be used to weight speakers when applying DBAP to sounds
with assigned installations.