### PR TITLE
Add support for recursively searching "audio" directory for WAVs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 time_calc = { version = "0.13", features = ["serde"] }
 toml = "0.4"
+walkdir = "2"
 
 [features]
 test_with_stereo = [] # Compile with this feature to set the max i/o channels as `2`.

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -19,6 +19,7 @@ extern crate serde_derive;
 extern crate serde_json;
 extern crate time_calc;
 extern crate toml;
+extern crate walkdir;
 
 use nannou::prelude::*;
 use soundscape::Soundscape;


### PR DESCRIPTION
This also updates the relative-path checking (useful in case the project
is moved between computers) to account for nested directories.

The `walkdir` crate has been added in order to perform the recursive
directory walk.