### PR TITLE
Add "occurrence rate" and "simultaneous sounds" range sliders to GUI

### DIFF
--- a/src/lib/gui/source_editor.rs
+++ b/src/lib/gui/source_editor.rs
@@ -1,7 +1,7 @@
 use audio;
 use audio::source::Role;
 use audio::source::wav::Playback;
-use gui::{collapsible_area, Gui, State};
+use gui::{collapsible_area, duration_label, Gui, State};
 use gui::{DARK_A, ITEM_HEIGHT, SMALL_FONT_SIZE};
 use installation::{self, Installation};
 use metres::Metres;
@@ -1151,32 +1151,10 @@ pub fn set(last_area_id: widget::Id, gui: &mut Gui) -> widget::Id {
             }
 
             // Playback duration.
-            const SEC_MS: f32 = 1_000.0;
-            const MIN_MS: f32 = SEC_MS * 60.0;
-            const HR_MS: f32 = MIN_MS * 60.0;
-            const DAY_MS: f32 = HR_MS * 24.0;
+            let label = duration_label(&realtime.duration);
             let min = 0.0;
-            let max = HR_MS;
-            let ms = realtime.duration.ms() as f32;
-            let label = if ms < SEC_MS {
-                format!("{:.2} ms", ms)
-            } else if ms < MIN_MS {
-                let secs = (ms / SEC_MS) as u32;
-                let ms = ms - (secs as f32 * SEC_MS);
-                format!("{} secs {:.2} ms", secs, ms)
-            } else if ms < HR_MS {
-                let mins = (ms / MIN_MS) as u32;
-                let secs = (ms - (mins as f32 * MIN_MS)) / SEC_MS;
-                format!("{} mins {:.2} secs", mins, secs)
-            } else if ms < DAY_MS {
-                let hrs = (ms / HR_MS) as u32;
-                let mins = (ms - (hrs as f32 * HR_MS)) / MIN_MS;
-                format!("{} hrs {:.2} mins", hrs, mins)
-            } else {
-                let days = ms / DAY_MS;
-                format!("{:.2} days", days)
-            };
-            for new_ms in widget::Slider::new(ms, min, max)
+            let max = utils::HR_MS;
+            for new_ms in widget::Slider::new(realtime.duration.ms(), min, max)
                 .label(&format!("Duration: {}", label))
                 .label_font_size(SMALL_FONT_SIZE)
                 .kid_area_w_of(ids.source_editor_selected_realtime_canvas)

--- a/src/lib/soundscape/group.rs
+++ b/src/lib/soundscape/group.rs
@@ -2,10 +2,38 @@
 //!
 //! Soundscape groups allow for describing rules/constraints for multiple sounds at once.
 
+use time_calc::Ms;
+use utils::Range;
+
 /// A name for a soundscape group.
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialOrd, Ord, PartialEq, Hash, Deserialize, Serialize)]
 pub struct Name(pub String);
 
 /// A more efficient unique identifier for a group.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub struct Id(pub usize);
+
+/// A soundscape group.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct Group {
+    pub occurrence_rate: Range<Ms>,
+    pub simultaneous_sounds: Range<usize>,
+}
+
+pub mod default {
+    use time_calc::Ms;
+    use utils::{HR_MS, Range};
+    pub const OCCURRENCE_RATE: Range<Ms> = Range { min: Ms(0.0), max: Ms(HR_MS as _) };
+    pub const SIMULTANEOUS_SOUNDS: Range<usize> = Range { min: 1, max: 10 };
+}
+
+impl Default for Group {
+    fn default() -> Self {
+        let occurrence_rate = default::OCCURRENCE_RATE;
+        let simultaneous_sounds = default::SIMULTANEOUS_SOUNDS;
+        Group {
+            occurrence_rate,
+            simultaneous_sounds,
+        }
+    }
+}


### PR DESCRIPTION
**Occurrence Rate**

This allows for specifying the rate at which new sounds may be spawned
for a soundscape group.

**Simultaneous Sounds**

This allows for specifying the minimum and maximum number of sounds that
can be played at once.

Closes #55.