### PR TITLE
Make sure "previewed" sounds always play back through all speakers

### DIFF
--- a/src/lib/gui/source_editor.rs
+++ b/src/lib/gui/source_editor.rs
@@ -751,15 +751,18 @@ pub fn set(last_area_id: widget::Id, gui: &mut Gui) -> widget::Id {
                 None => {
                     let sound_id = sound_id_gen.generate_next();
                     preview.current = Some((new_mode, sound_id));
+
                     // Set the preview position to the centre of the camera if not yet set.
                     if preview.point.is_none() {
                         preview.point = Some(camera.position);
                     }
+
                     // Send the selected source to the audio thread for playback.
                     let should_cycle = match new_mode {
                         SourcePreviewMode::OneShot => false,
                         SourcePreviewMode::Continuous => true,
                     };
+
                     // No attack or release for previews.
                     let attack_duration = Samples(0);
                     let release_duration = Samples(0);
@@ -768,10 +771,16 @@ pub fn set(last_area_id: widget::Id, gui: &mut Gui) -> widget::Id {
                         point: preview.point.unwrap(),
                         radians: 0.0,
                     };
+
+                    // When previewing sounds, remove the role so they play back through all
+                    // speakers.
+                    let mut audio = source.audio.clone();
+                    audio.role = None;
+
                     let _handle = audio::sound::spawn_from_source(
                         sound_id,
                         source.id,
-                        &source.audio,
+                        &audio,
                         position,
                         attack_duration,
                         release_duration,

--- a/src/lib/utils.rs
+++ b/src/lib/utils.rs
@@ -86,13 +86,15 @@ where
 /// Convert the given interval in milliseconds to a rate in hz.
 pub fn ms_interval_to_hz(ms: Ms) -> f64 {
     let secs_interval = ms.ms() / SEC_MS;
-    1.0 / secs_interval
+    let hz = 1.0 / secs_interval;
+    hz
 }
 
 /// Convert the given rate in hz to an interval in milliseconds.
 pub fn hz_to_ms_interval(hz: f64) -> Ms {
     let secs_interval = 1.0 / hz;
-    Ms(secs_interval * SEC_MS)
+    let ms = Ms(secs_interval * SEC_MS);
+    ms
 }
 
 /// Given a value in hz, produce a more readable "times per second".


### PR DESCRIPTION
Previously when previewing soundscape sources the preview sound would
only play back through speakers associated with the installations
assigned to the source. This behaviour was particularly confusing when
switching to the "SCAPE" mode and attempting to preview as by default a
soundscape source is not assigned to any installations and in turn would
not play back through any speakers. Now, previewed sounds will always
play back through all speakers despite their soundscape assignments (or
lack thereof).

Closes #93.