### PR TITLE
Change rotation default so that stereo channels are left and right

### DIFF
--- a/src/lib/audio/source/mod.rs
+++ b/src/lib/audio/source/mod.rs
@@ -610,7 +610,7 @@ pub mod default {
 
     pub const SPREAD: Metres = Metres(2.5);
     // Rotate the channel radians 90deg so that stereo channels are to the side by default.
-    pub const CHANNEL_RADIANS: f32 = ::std::f32::consts::PI * 0.25;
+    pub const CHANNEL_RADIANS: f32 = ::std::f32::consts::PI * 0.5;
     pub const VOLUME: f32 = 0.6;
     pub const OCCURRENCE_RATE: Range<Ms> = Range { min: Ms(500.0), max: Ms(HR_MS as _) };
     pub const SIMULTANEOUS_SOUNDS: Range<usize> = Range { min: 0, max: 1 };


### PR DESCRIPTION
Currently sources default to a strange radians offset resulting in the
left channel being to the front left and the right channel behind to the
right. This changes the default so that the first channel is directly to
the left and the second is directly to the right.