### PR TITLE
Fix bug where "Simultaneous Sounds" slider would disappear

### DIFF
--- a/src/lib/gui/installation_editor.rs
+++ b/src/lib/gui/installation_editor.rs
@@ -535,7 +535,7 @@ pub fn set(last_area_id: widget::Id, gui: &mut Gui) -> widget::Id {
         .align_left()
         .label(&label)
         .down(PAD * 2.0)
-        .set(ids.soundscape_editor_simultaneous_sounds_slider, ui)
+        .set(ids.installation_editor_soundscape_simultaneous_sounds_slider, ui)
     {
         let num = value as usize;
 


### PR DESCRIPTION
Currently the "Simultaneous Sounds" slider used within the "Installation
Editor" is accidentally shared with the same slider in the "Soundscape
Editor" panel. This would cause the Installation Editor's slider to
disappear whenever the Soundscape Editor panel was open.

This PR fixes this issue so that both panels use their own unique
sliders.

Closes #92.