### PR TITLE
Amplify noise walk to reach min and max simultaneous sounds

### DIFF
--- a/src/lib/soundscape/mod.rs
+++ b/src/lib/soundscape/mod.rs
@@ -950,7 +950,8 @@ fn installation_target_sounds(
     let mut rng = XorShiftRng::from_seed(noise_walk_seed);
     let phase_offset: f64 = rng.gen();
     let phase = phase_offset + playback_secs * hz;
-    let amp = noise_walk(phase);
+    // Amplify the noise_walk slightly so that it occasionally reaches min and max.
+    let amp = (noise_walk(phase) * 1.5).min(1.0).max(-1.0);
     let normalised_amp = amp * 0.5 + 0.5;
     let range = &constraints.simultaneous_sounds;
     let range_diff = range.max - range.min;


### PR DESCRIPTION
The soundscape currently uses a "noise walk" to create a "target" number
of sounds for each installation by oscillating between their specified
minimum and maximum simultaneous sounds over time at a very low
frequency. One issue with the noise walk is that it rarely reaches the
-1.0 or 1.0 exactly. This commit amplifies the noisewalk slightly to
reach closer to these bounds, but clamps the values to ensure it does
not exceed them.

Closes #94.