### PR TITLE
Loop at 60FPS rather than waiting for events. Improves macos performance

### DIFF
--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -52,9 +52,6 @@ struct Model {
 
 // Initialise the state of the application.
 fn model(app: &App) -> Model {
-    // Don't keep looping, just wait for events.
-    app.set_loop_mode(LoopMode::wait(3));
-
     // Find the assets directory.
     let assets = app.assets_path()
         .expect("could not find assets directory");
@@ -168,7 +165,7 @@ fn model(app: &App) -> Model {
 }
 
 // Update the application in accordance with the given event.
-fn event(app: &App, mut model: Model, event: Event) -> Model {
+fn event(_app: &App, mut model: Model, event: Event) -> Model {
     match event {
         Event::WindowEvent {
             simple: Some(_event),
@@ -176,14 +173,6 @@ fn event(app: &App, mut model: Model, event: Event) -> Model {
         } => {}
         Event::Update(_update) => {
             model.gui.update();
-
-            // If there are active sounds playing we should loop at a consistent rate for
-            // visualisation. Otherwise, only update on interactions.
-            if model.gui.is_animating() {
-                app.set_loop_mode(LoopMode::rate_fps(60.0));
-            } else {
-                app.set_loop_mode(LoopMode::wait(3));
-            }
         }
         _ => (),
     }


### PR DESCRIPTION
Currently rather than looping constantly, the audio server stops looping
if there are no active animations until the next user input is received.
This is often a great energy-saving exercise for gui apps, however the
audio server will almost always be animating due to the sounds that are
playing back and in turn there is little benefit of having this mode
enabled. This should speed up the macos build significantly as the
method used to "wake up" the app event loop is surprisingly expensive
and shows up as one of the primary bottlenecks.