### PR TITLE
 Colour sounds over the floorplan based on there soloed/muted state 

### DIFF
--- a/src/lib/gui/custom_widget/sound.rs
+++ b/src/lib/gui/custom_widget/sound.rs
@@ -170,8 +170,8 @@ impl<'a> Widget for Sound<'a> {
                 .parent(id)
                 .set(line_id, ui);
 
-            let radius_amp = radius * amp as f64;
-            let channel_radius = radius * 0.75 + radius_amp;
+            let radius_amp = radius * (amp as f64) * 1.2;
+            let channel_radius = radius * 0.6 + radius_amp;
             widget::Circle::fill(channel_radius)
                 .x_y(ch_x, ch_y)
                 .color(color)

--- a/src/lib/gui/mod.rs
+++ b/src/lib/gui/mod.rs
@@ -1730,7 +1730,7 @@ fn set_widgets(gui: &mut Gui) {
                         continue;
                     }
                     const MAX_THICKNESS: Scalar = 16.0;
-                    let amp = channel_amp * amp_scaler;
+                    let amp = (channel_amp * amp_scaler).powf(0.75);
                     let thickness = amp as Scalar * MAX_THICKNESS;
                     let speaker_point_m = speakers[speaker_index].audio.point;
                     let (s_x, s_y) = position_metres_to_gui(speaker_point_m, &state.camera);
@@ -1744,7 +1744,7 @@ fn set_widgets(gui: &mut Gui) {
 
                     let line_id = ids.floorplan_channel_to_speaker_lines[line_index];
                     widget::Line::abs([ch_x, ch_y], [s_x, s_y])
-                        .color(line_color.alpha(amp_scaler))
+                        .color(line_color.alpha(amp_scaler.powf(0.75)))
                         .depth(1.0)
                         .thickness(thickness)
                         .parent(ids.floorplan)


### PR DESCRIPTION
- Normal unmuted, unsoloed sounds are still blue.
- Sounds spawned from soloed sources are now yellow.
- If a sound is silent due to being muted or because some other source
is soloed the sounds will be gray.

This PR also emphasises channel amplitudes on floorplan visualisation.

Closes #104.