### PR TITLE
Fix bug where some sidebar panels would not allow swipe/mouse scrolling.

### DIFF
--- a/src/lib/gui/mod.rs
+++ b/src/lib/gui/mod.rs
@@ -1085,6 +1085,7 @@ pub fn collapsible_area(
     widget::CollapsibleArea::new(is_open, text)
         .w_of(side_menu_id)
         .h(ITEM_HEIGHT)
+        .parent(side_menu_id)
 }
 
 // Begin building a basic info text block.

--- a/src/lib/gui/soundscape_editor.rs
+++ b/src/lib/gui/soundscape_editor.rs
@@ -101,7 +101,6 @@ pub fn set(last_area_id: widget::Id, gui: &mut Gui) -> widget::Id {
 
     // The canvas on which the soundscape editor will be placed.
     let canvas = widget::Canvas::new()
-        .scroll_kids()
         .pad(PAD)
         .h(soundscape_editor_canvas_h);
     area.set(canvas, ui);

--- a/src/lib/gui/source_editor.rs
+++ b/src/lib/gui/source_editor.rs
@@ -305,7 +305,6 @@ pub fn set(last_area_id: widget::Id, gui: &mut Gui) -> widget::Id {
 
     // The canvas on which the source editor will be placed.
     let canvas = widget::Canvas::new()
-        .scroll_kids()
         .pad(0.0)
         .h(source_editor_canvas_h);
     area.set(canvas, gui);

--- a/src/lib/gui/speaker_editor.rs
+++ b/src/lib/gui/speaker_editor.rs
@@ -87,7 +87,6 @@ pub fn set(last_area_id: widget::Id, gui: &mut Gui) -> widget::Id {
 
     // The canvas on which the log will be placed.
     let canvas = widget::Canvas::new()
-        .scroll_kids()
         .pad(0.0)
         .h(speaker_editor_canvas_h);
     area.set(canvas, gui);


### PR DESCRIPTION
This bug particularly causes a lot of frustration when editing many
sources as the user has to move the mouse to the scrollbar and manually
click and drag it in order to navigate up and down the area. This commit
fixes swipe/mouse scrolling behaviour so that it should work in all
side-bar GUI areas.

Closes #96.