### PR TITLE
Replace all uses of std hasher with fxhasher

### DIFF
--- a/src/lib/audio/input.rs
+++ b/src/lib/audio/input.rs
@@ -4,9 +4,9 @@
 
 use audio::MAX_CHANNELS;
 use audio::source;
+use fxhash::FxHashMap;
 use nannou;
 use nannou::audio::Buffer;
-use std::collections::HashMap;
 use std::sync::{mpsc, Arc};
 use std::sync::atomic::{self, AtomicBool};
 
@@ -16,11 +16,11 @@ pub type Stream = nannou::audio::Stream<Model>;
 /// The state stored on each device's input audio stream.
 pub struct Model {
     // All sources that currently exist.
-    pub sources: HashMap<source::Id, source::Realtime>,
+    pub sources: FxHashMap<source::Id, source::Realtime>,
     // A map from channels to the sources that request audio from them them.
-    channel_targets: HashMap<usize, Vec<source::Id>>,
+    channel_targets: FxHashMap<usize, Vec<source::Id>>,
     // The currently active sounds using the realtime source with the given source ID.
-    pub active_sounds: HashMap<source::Id, Vec<ActiveSound>>,
+    pub active_sounds: FxHashMap<source::Id, Vec<ActiveSound>>,
 }
 
 /// The duration of an active sound's playback.
@@ -50,11 +50,11 @@ impl Model {
     /// This pre-allocates all possibly required memory for all of the model's buffers in order to
     /// avoid unexpected dynamic allocation within on the audio thread.
     pub fn new() -> Self {
-        let sources = HashMap::with_capacity(1024);
+        let sources = Default::default();
         let channel_targets = (0..MAX_CHANNELS)
             .map(|i| (i, Vec::with_capacity(1024)))
             .collect();
-        let active_sounds = HashMap::with_capacity(1024);
+        let active_sounds = Default::default();
         Model {
             sources,
             channel_targets,

--- a/src/lib/audio/output.rs
+++ b/src/lib/audio/output.rs
@@ -7,6 +7,7 @@ use audio::{DISTANCE_BLUR, PROXIMITY_LIMIT_2, Sound, Speaker, MAX_CHANNELS};
 use audio::detector::{EnvDetector, Fft, FftDetector, FFT_WINDOW_LEN};
 use audio::{dbap, source, sound, speaker};
 use audio::fft;
+use fxhash::{FxHashMap, FxHashSet};
 use gui;
 use installation::{self, Installation};
 use metres::Metres;
@@ -18,7 +19,6 @@ use rustfft::num_complex::Complex;
 use rustfft::num_traits::Zero;
 use soundscape;
 use std;
-use std::collections::{HashMap, HashSet};
 use std::sync::mpsc;
 use utils;
 
@@ -75,13 +75,13 @@ pub struct Model {
     /// The DBAP rolloff decibel amount, used to attenuate speaker gains over distances.
     pub dbap_rolloff_db: f64,
     /// The set of sources that are currently soloed. If not empty, only these sounds should play.
-    pub soloed: HashSet<source::Id>,
+    pub soloed: FxHashSet<source::Id>,
     /// A map from audio sound IDs to the audio sounds themselves.
-    sounds: HashMap<sound::Id, ActiveSound>,
+    sounds: FxHashMap<sound::Id, ActiveSound>,
     /// A map from speaker IDs to the speakers themselves.
-    speakers: HashMap<speaker::Id, ActiveSpeaker>,
+    speakers: FxHashMap<speaker::Id, ActiveSpeaker>,
     // /// A map from a speaker's assigned channel to the ID of the speaker.
-    // channel_to_speaker: HashMap<usize, speaker::Id>,
+    // channel_to_speaker: FxHashMap<usize, speaker::Id>,
     /// A buffer for collecting the speakers within proximity of the sound's position.
     unmixed_samples: Vec<f32>,
     /// A buffer for collecting sounds that have been removed due to completing.
@@ -93,7 +93,7 @@ pub struct Model {
     /// A handle to the soundscape thread - for notifying when a sound is complete.
     soundscape_tx: mpsc::Sender<soundscape::Message>,
     /// An analysis per installation to re-use for sending to the OSC output thread.
-    installation_analyses: HashMap<Installation, Vec<SpeakerAnalysis>>,
+    installation_analyses: FxHashMap<Installation, Vec<SpeakerAnalysis>>,
     /// A buffer to re-use for DBAP speaker calculations.
     ///
     /// The index of the speaker is its channel.
@@ -131,10 +131,10 @@ impl Model {
         let soloed = Default::default();
 
         // A map from audio sound IDs to the audio sounds themselves.
-        let sounds = HashMap::with_capacity(1024);
+        let sounds = Default::default();
 
         // A map from speaker IDs to the speakers themselves.
-        let speakers = HashMap::with_capacity(MAX_CHANNELS);
+        let speakers = Default::default();
 
         // A buffer for collecting frames from `Sound`s that have not yet been mixed and written.
         let unmixed_samples = vec![0.0; 1024];

--- a/src/lib/audio/sound.rs
+++ b/src/lib/audio/sound.rs
@@ -1,8 +1,8 @@
 use audio::{input, output, source, Source, SAMPLE_RATE};
+use fxhash::FxHashSet;
 use installation::Installation;
 use metres::Metres;
 use nannou::math::Point2;
-use std::collections::HashSet;
 use std::ops;
 use std::sync::{mpsc, Arc, Mutex};
 use std::sync::atomic::{self, AtomicBool};
@@ -425,7 +425,7 @@ impl Sound {
 #[derive(Debug)]
 pub enum Installations {
     All,
-    Set(HashSet<Installation>),
+    Set(FxHashSet<Installation>),
 }
 
 impl From<Option<source::Role>> for Installations {

--- a/src/lib/audio/source/mod.rs
+++ b/src/lib/audio/source/mod.rs
@@ -1,9 +1,9 @@
+use fxhash::FxHashSet;
 use installation::Installation;
 use metres::Metres;
 use nannou::math::map_range;
 use nannou::rand::Rng;
 use soundscape;
-use std::collections::HashSet;
 use std::ops;
 use time_calc::{Ms, Samples};
 use utils::{self, Range};
@@ -135,9 +135,9 @@ pub enum Role {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct Soundscape {
     #[serde(default)]
-    pub installations: HashSet<Installation>,
+    pub installations: FxHashSet<Installation>,
     #[serde(default)]
-    pub groups: HashSet<soundscape::group::Id>,
+    pub groups: FxHashSet<soundscape::group::Id>,
     #[serde(default = "default::occurrence_rate")]
     pub occurrence_rate: Range<Ms>,
     #[serde(default = "default::simultaneous_sounds")]

--- a/src/lib/audio/speaker.rs
+++ b/src/lib/audio/speaker.rs
@@ -1,8 +1,8 @@
 use audio;
+use fxhash::FxHashSet;
 use installation::Installation;
 use metres::Metres;
 use nannou::math::Point2;
-use std::collections::HashSet;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub struct Id(pub u64);
@@ -18,13 +18,13 @@ pub struct Speaker {
     pub channel: usize,
     // Installations assigned to this speaker.
     #[serde(default)]
-    pub installations: HashSet<Installation>,
+    pub installations: FxHashSet<Installation>,
 }
 
 /// Calculate a speaker's DBAP weight taking into consideration its assigned installations.
 pub fn dbap_weight(
     sound_installations: &audio::sound::Installations,
-    speaker_installations: &HashSet<Installation>,
+    speaker_installations: &FxHashSet<Installation>,
 ) -> f64
 {
     match *sound_installations {

--- a/src/lib/gui/installation_editor.rs
+++ b/src/lib/gui/installation_editor.rs
@@ -1,3 +1,4 @@
+use fxhash::FxHashMap;
 use gui::{self, collapsible_area, Channels, Gui};
 use gui::{ITEM_HEIGHT, SMALL_FONT_SIZE};
 use installation::{self, ComputerId, Installation};
@@ -6,7 +7,6 @@ use nannou::osc::Connected;
 use nannou::ui;
 use nannou::ui::prelude::*;
 use osc;
-use std::collections::HashMap;
 use std::{io, net, ops};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17,8 +17,8 @@ pub struct Address {
     pub osc_addr: String,
 }
 
-pub type AddressMap = HashMap<ComputerId, Address>;
-pub type ComputerMap = HashMap<Installation, AddressMap>;
+pub type AddressMap = FxHashMap<ComputerId, Address>;
+pub type ComputerMap = FxHashMap<Installation, AddressMap>;
 
 pub struct InstallationEditor {
     pub is_open: bool,
@@ -29,7 +29,7 @@ pub struct InstallationEditor {
 /// State to be serialized/deserialized.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct State {
-    pub installations: HashMap<Installation, installation::Soundscape>,
+    pub installations: FxHashMap<Installation, installation::Soundscape>,
     pub computer_map: ComputerMap,
 }
 

--- a/src/lib/gui/mod.rs
+++ b/src/lib/gui/mod.rs
@@ -1,5 +1,6 @@
 use audio;
 use config::Config;
+use fxhash::FxHashMap;
 use interaction::Interaction;
 use metres::Metres;
 use nannou;
@@ -11,7 +12,7 @@ use osc;
 use osc::input::Log as OscInputLog;
 use osc::output::Log as OscOutputLog;
 use soundscape::{self, Soundscape};
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 use std::ops::{Deref, DerefMut};
 use std::sync::mpsc;
@@ -55,7 +56,7 @@ const SOUNDSCAPE_FILE_STEM: &'static str = "soundscape";
 // The name of the directory where the WAVs are stored.
 const AUDIO_DIRECTORY_NAME: &'static str = "audio";
 
-type ActiveSoundMap = HashMap<audio::sound::Id, ActiveSound>;
+type ActiveSoundMap = FxHashMap<audio::sound::Id, ActiveSound>;
 
 pub struct Model {
     pub ui: Ui,
@@ -188,8 +189,8 @@ impl Model {
         let state = State::new(assets, config, &channels, audio_channels);
 
         // Initialise the audio monitor.
-        let active_sounds = HashMap::new();
-        let speakers = HashMap::new();
+        let active_sounds = Default::default();
+        let speakers = Default::default();
         let audio_monitor = AudioMonitor {
             active_sounds,
             speakers,
@@ -805,7 +806,7 @@ impl<T> Deref for Log<T> {
 // A structure for monitoring the state of the audio thread for visualisation.
 struct AudioMonitor {
     active_sounds: ActiveSoundMap,
-    speakers: HashMap<audio::speaker::Id, ChannelLevels>,
+    speakers: FxHashMap<audio::speaker::Id, ChannelLevels>,
 }
 
 // The state of an active sound.

--- a/src/lib/gui/soundscape_editor.rs
+++ b/src/lib/gui/soundscape_editor.rs
@@ -3,12 +3,12 @@
 //! - Play/Pause toggle for the soundscape.
 //! - Groups panel for creating/removing soundscape source groups.
 
+use fxhash::FxHashMap;
 use gui::{collapsible_area, hz_label, Gui, State};
 use gui::{ITEM_HEIGHT, SMALL_FONT_SIZE};
 use nannou::ui;
 use nannou::ui::prelude::*;
 use soundscape;
-use std::collections::HashMap;
 use std::ops;
 use time_calc::Ms;
 use utils;
@@ -16,7 +16,7 @@ use utils;
 /// GUI state related to the soundscape editor area.
 pub struct SoundscapeEditor {
     pub is_open: bool,
-    pub groups: HashMap<soundscape::group::Id, Group>,
+    pub groups: FxHashMap<soundscape::group::Id, Group>,
     pub next_group_id: soundscape::group::Id,
     pub selected: Option<Selected>,
 }
@@ -31,7 +31,7 @@ pub struct Group {
 /// JSON friendly representation of the soundscape editor GUI state.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Stored {
-    pub groups: HashMap<soundscape::group::Id, Group>,
+    pub groups: FxHashMap<soundscape::group::Id, Group>,
     pub next_group_id: soundscape::group::Id,
 }
 

--- a/src/lib/gui/source_editor.rs
+++ b/src/lib/gui/source_editor.rs
@@ -1,6 +1,7 @@
 use audio;
 use audio::source::Role;
 use audio::source::wav::Playback;
+use fxhash::FxHashSet;
 use gui::{collapsible_area, duration_label, hz_label, Gui, State};
 use gui::{DARK_A, ITEM_HEIGHT, SMALL_FONT_SIZE};
 use installation::{self, Installation};
@@ -10,7 +11,6 @@ use nannou::ui;
 use nannou::ui::prelude::*;
 use soundscape;
 use std;
-use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::mem;
 use std::ops;
@@ -23,7 +23,7 @@ pub struct SourceEditor {
     pub is_open: bool,
     pub sources: Vec<Source>,
     // The tracks that currently have solo enabled.
-    pub soloed: HashSet<audio::source::Id>,
+    pub soloed: FxHashSet<audio::source::Id>,
     // The index of the selected source.
     pub selected: Option<usize>,
     // The next ID to be used for a new source.
@@ -58,7 +58,7 @@ pub struct StoredSources {
     #[serde(default = "first_source_id")]
     pub next_id: audio::source::Id,
     #[serde(default)]
-    pub soloed: HashSet<audio::source::Id>,
+    pub soloed: FxHashSet<audio::source::Id>,
 }
 
 pub fn first_source_id() -> audio::source::Id {

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -7,6 +7,7 @@ extern crate conrod;
 extern crate conrod_derive;
 #[macro_use]
 extern crate custom_derive;
+extern crate fxhash;
 extern crate hound; // wav loading
 extern crate nannou;
 #[macro_use]

--- a/src/lib/osc/output.rs
+++ b/src/lib/osc/output.rs
@@ -1,8 +1,8 @@
+use fxhash::FxHashMap;
 use installation::{ComputerId, Installation};
 use nannou::osc;
 use nannou::osc::Type::{Float, Int};
 use std;
-use std::collections::HashMap;
 use std::iter::once;
 use std::sync::mpsc;
 
@@ -87,8 +87,8 @@ fn run(msg_rx: mpsc::Receiver<Message>, log_tx: mpsc::Sender<Log>) {
     }
 
     // Each installation gets its own map of ComputerId -> Target.
-    type TargetMap = HashMap<ComputerId, Target>;
-    let mut osc_txs: HashMap<Installation, TargetMap> = HashMap::new();
+    type TargetMap = FxHashMap<ComputerId, Target>;
+    let mut osc_txs: FxHashMap<Installation, TargetMap> = Default::default();
 
     // Update channel.
     let (update_tx, update_rx) = mpsc::channel();
@@ -118,8 +118,8 @@ fn run(msg_rx: mpsc::Receiver<Message>, log_tx: mpsc::Sender<Log>) {
         .unwrap();
 
     // A map containing the latest data received in terms of messages.
-    let mut last_received = HashMap::new();
-    let mut last_sent = HashMap::new();
+    let mut last_received = FxHashMap::default();
+    let mut last_sent = FxHashMap::default();
     for update in update_rx {
         match update {
             Update::Msg(msg) => match msg {
@@ -132,7 +132,7 @@ fn run(msg_rx: mpsc::Receiver<Message>, log_tx: mpsc::Sender<Log>) {
                     OscTarget::Add(installation, computer, osc_tx, osc_addr) => {
                         osc_txs
                             .entry(installation)
-                            .or_insert_with(HashMap::default)
+                            .or_insert_with(FxHashMap::default)
                             .insert(computer, Target { osc_tx, osc_addr });
                     }
                     OscTarget::Remove(installation, computer) => {

--- a/src/lib/soundscape/mod.rs
+++ b/src/lib/soundscape/mod.rs
@@ -1,4 +1,5 @@
 use audio;
+use fxhash::{FxHashMap, FxHashSet};
 use installation::{self, Installation};
 use metres::Metres;
 use mindtree_utils::noise_walk;
@@ -6,7 +7,6 @@ use nannou;
 use nannou::prelude::*;
 use nannou::rand::{Rng, SeedableRng, XorShiftRng};
 use std::cmp;
-use std::collections::{HashMap, HashSet};
 use std::ops;
 use std::sync::atomic::AtomicBool;
 use std::sync::{atomic, mpsc, Arc, Mutex};
@@ -24,18 +24,18 @@ pub mod movement;
 
 const TICK_RATE_MS: u64 = 16;
 
-type Installations = HashMap<Installation, installation::Soundscape>;
-type Groups = HashMap<group::Id, Group>;
-type Sources = HashMap<audio::source::Id, Source>;
-type Speakers = HashMap<audio::speaker::Id, Speaker>;
-type GroupsLastUsed = HashMap<group::Id, time::Instant>;
-type SourcesLastUsed = HashMap<audio::source::Id, time::Instant>;
-type InstallationAreas = HashMap<Installation, movement::Area>;
-type InstallationSpeakers = HashMap<Installation, Vec<audio::speaker::Id>>;
-type ActiveSounds = HashMap<audio::sound::Id, ActiveSound>;
-type ActiveSoundPositions = HashMap<audio::sound::Id, ActiveSoundPosition>;
-type ActiveSoundsPerInstallation = HashMap<Installation, Vec<audio::sound::Id>>;
-type TargetSoundsPerInstallation = HashMap<Installation, usize>;
+type Installations = FxHashMap<Installation, installation::Soundscape>;
+type Groups = FxHashMap<group::Id, Group>;
+type Sources = FxHashMap<audio::source::Id, Source>;
+type Speakers = FxHashMap<audio::speaker::Id, Speaker>;
+type GroupsLastUsed = FxHashMap<group::Id, time::Instant>;
+type SourcesLastUsed = FxHashMap<audio::source::Id, time::Instant>;
+type InstallationAreas = FxHashMap<Installation, movement::Area>;
+type InstallationSpeakers = FxHashMap<Installation, Vec<audio::speaker::Id>>;
+type ActiveSounds = FxHashMap<audio::sound::Id, ActiveSound>;
+type ActiveSoundPositions = FxHashMap<audio::sound::Id, ActiveSoundPosition>;
+type ActiveSoundsPerInstallation = FxHashMap<Installation, Vec<audio::sound::Id>>;
+type TargetSoundsPerInstallation = FxHashMap<Installation, usize>;
 
 /// The kinds of messages received by the soundscape thread.
 pub enum Message {
@@ -85,7 +85,7 @@ pub struct Speaker {
     /// The position of the speaker in metres.
     pub point: Point2<Metres>,
     /// All installations assigned to the speaker.
-    pub installations: HashSet<Installation>,
+    pub installations: FxHashSet<Installation>,
 }
 
 /// Properties of an audio source that are relevant to the soundscape thread.
@@ -1016,7 +1016,7 @@ fn tick(model: &mut Model, tick: Tick) {
     //
     // We can determine this in a purely functional manner by using the playback duration as the
     // phase for a noise_walk signal.
-    let mut target_sounds_per_installation: TargetSoundsPerInstallation = HashMap::default();
+    let mut target_sounds_per_installation: TargetSoundsPerInstallation = Default::default();
     update_target_sounds_per_installation(
         seed,
         &tick.playback_duration,

--- a/src/lib/soundscape/movement/agent.rs
+++ b/src/lib/soundscape/movement/agent.rs
@@ -1,9 +1,9 @@
 use audio;
+use fxhash::FxHashMap;
 use installation::Installation;
 use metres::Metres;
 use nannou::prelude::*;
 use nannou::rand::Rng;
-use std::collections::HashMap;
 use std::{cmp, time};
 use utils::{self, duration_to_secs, pt2, vt2};
 
@@ -49,7 +49,7 @@ pub struct InstallationData {
 }
 
 /// A map of installation data relevant to the agent.
-pub type InstallationDataMap = HashMap<Installation, InstallationData>;
+pub type InstallationDataMap = FxHashMap<Installation, InstallationData>;
 
 impl Agent {
     /// Generate a new agent starting in the given installation area.


### PR DESCRIPTION
The audio server uses around 20-30 unique hash maps for mapping unique
IDs and indices to some associated data. This commit switches to an
algorithm that is much better equipped to our use case and should
provide a multiple-times speed increase to all hash map lookups.

Closes #98.