### PR TITLE
Highlight sounds spawned from the currently selected source

### DIFF
--- a/src/lib/gui/custom_widget/sound.rs
+++ b/src/lib/gui/custom_widget/sound.rs
@@ -1,7 +1,7 @@
 //! A visual representation of a `Sound` for displaying over the floorplan.
 
 use metres::Metres;
-use nannou::ui::{self, Color};
+use nannou::ui::Color;
 use nannou::ui::prelude::*;
 use std;
 use utils;

--- a/src/lib/gui/mod.rs
+++ b/src/lib/gui/mod.rs
@@ -1647,13 +1647,26 @@ fn set_widgets(gui: &mut Gui) {
                     let position = active_sound.position;
                     let id = source.id;
                     let soloed = &state.source_editor.soloed;
-                    let color = if source.audio.muted || (!soloed.is_empty() && !soloed.contains(&id)) {
+                    let mut color = if source.audio.muted || (!soloed.is_empty() && !soloed.contains(&id)) {
                         color::LIGHT_CHARCOAL
                     } else if soloed.contains(&id) {
                         color::DARK_YELLOW
                     } else {
                         color::DARK_BLUE
                     };
+
+                    // If the source editor is open and this sound is selected, highlight it.
+                    if state.source_editor.is_open {
+                        if let Some(i) = selected {
+                            if let Some(selected) = state.source_editor.sources.get(i) {
+                                if selected.id == source.id {
+                                    let luminance = color.luminance();
+                                    color = color.with_luminance(luminance.powf(0.5));
+                                }
+                            }
+                        }
+                    }
+
                     (
                         spread,
                         channel_radians,


### PR DESCRIPTION
Previously it was difficult to distinguish between the sounds produced
from the source that you are currently editing and other sounds. This
commit highlights sounds that were spawned from the currently selected
source so it is much easier to see what sounds you are manipulating.