### PR TITLE
Round to nearest human-readable integer on rate and duration sliders

### DIFF
--- a/src/lib/gui/mod.rs
+++ b/src/lib/gui/mod.rs
@@ -907,19 +907,19 @@ pub fn info_text(text: &str) -> widget::Text {
 pub fn hz_label(hz: f64) -> String {
     match utils::human_readable_hz(hz) {
         (HumanReadableTime::Ms, times_per_ms) => {
-            format!("{:.2} per millisecond", times_per_ms)
+            format!("{} per millisecond", times_per_ms.round())
         },
         (HumanReadableTime::Secs, hz) => {
-            format!("{:.2} per second", hz)
+            format!("{} per second", hz.round())
         },
         (HumanReadableTime::Mins, times_per_min) => {
-            format!("{:.2} per minute", times_per_min)
+            format!("{} per minute", times_per_min.round())
         },
         (HumanReadableTime::Hrs, times_per_hr) => {
-            format!("{:.2} per hour", times_per_hr)
+            format!("{} per hour", times_per_hr.round())
         },
         (HumanReadableTime::Days, times_per_day) => {
-            format!("{:.2} per day", times_per_day)
+            format!("{} per day", times_per_day.round())
         },
     }
 }
@@ -929,25 +929,25 @@ pub fn duration_label(ms: &Ms) -> String {
     // Playback duration.
     match utils::human_readable_ms(ms) {
         (HumanReadableTime::Ms, ms) => {
-            format!("{:.2} ms", ms)
+            format!("{} ms", ms)
         },
         (HumanReadableTime::Secs, secs) => {
             let secs = secs.floor();
             let ms = ms.ms() - (secs * SEC_MS);
-            format!("{} secs {:.2} ms", secs, ms)
+            format!("{} secs {} ms", secs, ms)
         },
         (HumanReadableTime::Mins, mins) => {
             let mins = mins.floor();
             let secs = (ms.ms() - (mins * MIN_MS)) / SEC_MS;
-            format!("{} mins {:.2} secs", mins, secs)
+            format!("{} mins {} secs", mins, secs)
         },
         (HumanReadableTime::Hrs, hrs) => {
             let hrs = hrs.floor();
             let mins = (ms.ms() - (hrs * HR_MS)) / MIN_MS;
-            format!("{} hrs {:.2} mins", hrs, mins)
+            format!("{} hrs {} mins", hrs, mins)
         },
         (HumanReadableTime::Days, days) => {
-            format!("{:.2} days", days)
+            format!("{} days", days)
         },
     }
 }

--- a/src/lib/gui/soundscape_editor.rs
+++ b/src/lib/gui/soundscape_editor.rs
@@ -377,7 +377,10 @@ pub fn set(
         .down(PAD * 2.0)
         .set(ids.soundscape_editor_occurrence_rate_slider, ui)
     {
-        let hz = value as _;
+        let hz = {
+            let (unit, times_per_unit) = utils::human_readable_hz(value as _);
+            unit.times_per_unit_to_hz(times_per_unit.round())
+        };
         let id = selected.id;
 
         // Update the local copy.

--- a/src/lib/gui/source_editor.rs
+++ b/src/lib/gui/source_editor.rs
@@ -1493,7 +1493,10 @@ pub fn set(
                 .down(PAD * 2.0)
                 .set(ids.source_editor_selected_soundscape_occurrence_rate_slider, ui)
             {
-                let hz = value as _;
+                let hz = {
+                    let (unit, times_per_unit) = utils::human_readable_hz(value as _);
+                    unit.times_per_unit_to_hz(times_per_unit.round())
+                };
 
                 // Update the local copy.
                 let new_rate = {
@@ -1602,7 +1605,11 @@ pub fn set(
                 .down(PAD * 2.0)
                 .set(ids.source_editor_selected_soundscape_playback_duration_slider, ui)
             {
-                let duration = Ms(value as _);
+                let duration = {
+                    let (unit, value) = utils::human_readable_ms(&Ms(value as _));
+                    let (unit, value) = unit.to_finer_unit(value);
+                    unit.to_ms(value.round())
+                };
 
                 // Update the local copy.
                 let new_duration = {
@@ -1651,7 +1658,11 @@ pub fn set(
                 .down(PAD * 2.0)
                 .set(ids.source_editor_selected_soundscape_attack_duration_slider, ui)
             {
-                let duration = Ms(value);
+                let duration = {
+                    let (unit, value) = utils::human_readable_ms(&Ms(value as _));
+                    let (unit, value) = unit.to_finer_unit(value);
+                    unit.to_ms(value.round())
+                };
 
                 // Update the local copy.
                 let new_duration = {
@@ -1700,7 +1711,11 @@ pub fn set(
                 .down(PAD * 2.0)
                 .set(ids.source_editor_selected_soundscape_release_duration_slider, ui)
             {
-                let duration = Ms(value);
+                let duration = {
+                    let (unit, value) = utils::human_readable_ms(&Ms(value as _));
+                    let (unit, value) = unit.to_finer_unit(value);
+                    unit.to_ms(value.round())
+                };
 
                 // Update the local copy.
                 let new_duration = {

--- a/src/lib/utils.rs
+++ b/src/lib/utils.rs
@@ -54,6 +54,43 @@ pub enum HumanReadableTime {
     Days,
 }
 
+impl HumanReadableTime {
+    /// Convert the given "times per unit (self)" to hz.
+    pub fn times_per_unit_to_hz(&self, times_per_unit: f64) -> f64 {
+        match *self {
+            HumanReadableTime::Ms => times_per_unit * MS_IN_HZ,
+            HumanReadableTime::Secs => times_per_unit,
+            HumanReadableTime::Mins => times_per_unit * MIN_IN_HZ,
+            HumanReadableTime::Hrs => times_per_unit * HR_IN_HZ,
+            HumanReadableTime::Days => times_per_unit * DAY_IN_HZ,
+        }
+    }
+
+    /// Convert the given value to the next finer unit.
+    ///
+    /// If `self` is ms, ms is returned.
+    pub fn to_finer_unit(&self, value: f64) -> (HumanReadableTime, f64) {
+        match *self {
+            HumanReadableTime::Ms => (HumanReadableTime::Ms, value),
+            HumanReadableTime::Secs => (HumanReadableTime::Ms, value * SEC_MS),
+            HumanReadableTime::Mins => (HumanReadableTime::Secs, value * 60.0),
+            HumanReadableTime::Hrs => (HumanReadableTime::Mins, value * 60.0),
+            HumanReadableTime::Days => (HumanReadableTime::Hrs, value * 24.0),
+        }
+    }
+
+    /// Convert the given human readable value to Ms.
+    pub fn to_ms(&self, value: f64) -> Ms {
+        match *self {
+            HumanReadableTime::Ms => Ms(value),
+            HumanReadableTime::Secs => Ms(value * SEC_MS),
+            HumanReadableTime::Mins => Ms(value * MIN_MS),
+            HumanReadableTime::Hrs => Ms(value * HR_MS),
+            HumanReadableTime::Days => Ms(value * DAY_MS),
+        }
+    }
+}
+
 /// Sums seed `b` onto seed `a` in a wrapping manner.
 pub fn add_seeds(a: &Seed, b: &Seed) -> Seed {
     let s0 = a[0].wrapping_add(b[0]);


### PR DESCRIPTION
Specifically, this affects the:

- Soundscape group occurrence rate slider.
- Source occurrence rate slider.
- Source playback duration slider.
- Source fade-in duration slider.
- Source fade-out duration slider.

This makes the GUI a little easier to read and should make synchronising
some source behaviour slightly easier.

Closes #122.