### PR TITLE
Fix bug where realtime source would not playback

### DIFF
--- a/src/lib/audio/input.rs
+++ b/src/lib/audio/input.rs
@@ -67,7 +67,6 @@ impl Model {
     /// This is called when we switch between projects within the GUI.
     pub fn clear_project_specific_data(&mut self) {
         self.sources.clear();
-        self.channel_targets.clear();
         self.active_sounds.clear();
     }
 }


### PR DESCRIPTION
@MitchAllen1 I haven't been able to watch the vid you posted in the
issue yet (our net has been dropping out a lot tonight) but I noticed a
pretty glaring bug which was also causing realtime sources to
immediately cut out on *all* platforms, not just mac. Hopefully this
fixes it for you!

Closes #121.