### PR TITLE
Implement Custom Installations (Add, Remove, Rename)

### DIFF
--- a/src/lib/audio/dbap.rs
+++ b/src/lib/audio/dbap.rs
@@ -28,7 +28,7 @@ pub struct SpeakerGains<'a> {
 pub fn blurred_distance_2(source: Point2<f64>, speaker: Point2<f64>, blur: f64) -> f64 {
     let x = speaker.x - source.x;
     let y = speaker.y - source.y;
-    x * x + y * y + blur * blur
+    (x * x + y * y + blur * blur).max(::std::f64::EPSILON)
 }
 
 impl<'a> SpeakerGains<'a> {

--- a/src/lib/audio/sound.rs
+++ b/src/lib/audio/sound.rs
@@ -87,6 +87,12 @@ pub struct ChannelPoints<'a> {
     index: usize,
 }
 
+#[derive(Debug)]
+pub enum Installations {
+    All,
+    Set(FxHashSet<installation::Id>),
+}
+
 impl Shared {
     /// Whether or not the soundscape is currently playing.
     pub fn is_playing(&self) -> bool {
@@ -410,12 +416,6 @@ impl Sound {
     pub fn source_id(&self) -> source::Id {
         self.shared.source_id
     }
-}
-
-#[derive(Debug)]
-pub enum Installations {
-    All,
-    Set(FxHashSet<installation::Id>),
 }
 
 impl From<Option<source::Role>> for Installations {

--- a/src/lib/gui/mod.rs
+++ b/src/lib/gui/mod.rs
@@ -804,7 +804,11 @@ widget_ids! {
         control_log_scrollbar_x,
         // Installation Editor.
         installation_editor,
+        installation_editor_none,
         installation_editor_list,
+        installation_editor_add,
+        installation_editor_remove,
+        installation_editor_name,
         installation_editor_selected_canvas,
         installation_editor_computer_canvas,
         installation_editor_computer_text,

--- a/src/lib/osc/output.rs
+++ b/src/lib/osc/output.rs
@@ -22,6 +22,8 @@ pub enum OscTarget {
         String,
     ),
     Remove(installation::Id, installation::computer::Id),
+    RemoveInstallation(installation::Id),
+    UpdateAddr(installation::Id, installation::computer::Id, String),
 }
 
 /// Data related to a single frame of audio.
@@ -145,6 +147,16 @@ fn run(msg_rx: mpsc::Receiver<Message>, log_tx: mpsc::Sender<Log>) {
                     OscTarget::Remove(installation, computer) => {
                         if let Some(txs) = osc_txs.get_mut(&installation) {
                             txs.remove(&computer);
+                        }
+                    }
+                    OscTarget::RemoveInstallation(installation) => {
+                        osc_txs.remove(&installation);
+                    }
+                    OscTarget::UpdateAddr(installation, computer, addr) => {
+                        if let Some(txs) = osc_txs.get_mut(&installation) {
+                            if let Some(comp) = txs.get_mut(&computer) {
+                                comp.osc_addr = addr;
+                            }
                         }
                     }
                 },

--- a/src/lib/soundscape/mod.rs
+++ b/src/lib/soundscape/mod.rs
@@ -360,6 +360,29 @@ impl Model {
         self.installations.insert(installation, state)
     }
 
+    /// Remove the given installation.
+    ///
+    /// Also removes the installation from all sources and speakers assignments.
+    ///
+    /// TODO: Possibly remove all active sounds currently closest to the installation?
+    pub fn remove_installation(
+        &mut self,
+        id: &installation::Id,
+    ) -> Option<installation::Soundscape>
+    {
+        // Remove from speakers.
+        for speaker in self.speakers.values_mut() {
+            speaker.installations.remove(id);
+        }
+
+        // Remove from sources.
+        for source in self.sources.values_mut() {
+            source.installations.remove(id);
+        }
+
+        self.installations.remove(id)
+    }
+
     /// Update the given installation's state.
     ///
     /// Returns `false` if the installation was not there.
@@ -1021,7 +1044,7 @@ fn generate_movement(
 // A unique, constant seed associated with the installation.
 fn installation_seed(installation: &installation::Id) -> [u32; 4] {
     // Convert the installation to its integer representation.
-    let u = installation.to_u32();
+    let u = installation.0 as u32;
     let seed = [u; 4];
     seed
 }


### PR DESCRIPTION
This refactors the codebase to support custom installations.

Installations now support:

- Adding new isntallations via the "+" button
- Removing installations via the "x" button
- Editing installation names by editing in the textbox and pressing
`Enter`.

Note that when editing and entering a new installation name, the OSC
address will be updated to be the "slugified" (computer-friendly)
version of that name.

By default (if there is no existing state.json file) the audio server
will generate the known beyond perception installations.

The server still supports loading the original fixed installation
states, so it should be fine to use old projects with this version.