### PR TITLE
Fix a bug where switching between projects would sometimes crash

### DIFF
--- a/src/lib/gui/project_editor.rs
+++ b/src/lib/gui/project_editor.rs
@@ -22,6 +22,7 @@ pub fn set(
 ) -> widget::Id {
     let Gui {
         ref mut ui,
+        ref mut audio_monitor,
         ref ids,
         ref channels,
         ref assets,
@@ -81,6 +82,7 @@ pub fn set(
         let new_project = Project::new(assets, default_project_config);
         new_project.save(assets).expect("failed to create new project directory");
         new_project.reset_and_sync_all_threads(channels);
+        audio_monitor.clear();
         let new_project_state = ProjectState::default();
         project_editor.text_box_name = new_project.name.clone();
         *project = Some((new_project, new_project_state));
@@ -105,6 +107,7 @@ pub fn set(
             new_project.name = format!("{} copy", new_project.name);
             new_project.save(assets).expect("failed to create new project directory");
             new_project.reset_and_sync_all_threads(channels);
+            audio_monitor.clear();
             let new_project_state = ProjectState::default();
             project_editor.text_box_name = new_project.name.clone();
             *project = Some((new_project, new_project_state));
@@ -263,6 +266,7 @@ pub fn set(
                 // Load the project.
                 let loaded_project = Project::load(assets, &project_directory, default_project_config);
                 loaded_project.reset_and_sync_all_threads(channels);
+                audio_monitor.clear();
                 let loaded_project_state = ProjectState::default();
                 selected_project_slug = Some(slugify(&loaded_project.name));
                 project_editor.text_box_name = loaded_project.name.clone();
@@ -302,6 +306,7 @@ pub fn set(
             // Load the project.
             let loaded_project = Project::load(assets, &directory, default_project_config);
             loaded_project.reset_and_sync_all_threads(channels);
+            audio_monitor.clear();
             let loaded_project_state = ProjectState::default();
             project_editor.text_box_name = loaded_project.name.clone();
             *project = Some((loaded_project, loaded_project_state));


### PR DESCRIPTION
This was caused by the GUI attempting to display sounds that were sent
from the audio thread to the GUI thread between the moment the audio
monitor channel was checked and the moment a project was removed. The
GUI now validates all `AudioMonitor` state each update by checking that
they have associated sources within the currently selected project.