### PR TITLE
Fix bug where realtime selected playback duration was sometimes ignored

### DIFF
--- a/src/lib/audio/sound.rs
+++ b/src/lib/audio/sound.rs
@@ -315,9 +315,14 @@ pub fn spawn_from_realtime(
     }
 
     // The signal from which the sound will draw samples.
+    let remaining_samples = match duration {
+        input::Duration::Infinite => None,
+        input::Duration::Frames(frames) => Some(frames * n_channels),
+    };
     let samples = source::realtime::Signal {
         channels: n_channels,
         sample_rx,
+        remaining_samples,
     };
     let kind = source::SignalKind::Realtime { samples };
     let mut signal = source::Signal::new(kind, attack_duration_frames, release_duration_frames);

--- a/src/lib/audio/source/mod.rs
+++ b/src/lib/audio/source/mod.rs
@@ -393,7 +393,7 @@ impl SignalKind {
     fn remaining_frames(&self) -> Option<Samples> {
         match *self {
             SignalKind::Wav { ref samples, .. } => samples.remaining_frames(),
-            SignalKind::Realtime { .. } => None,
+            SignalKind::Realtime { ref samples } => samples.remaining_frames(),
         }
     }
 

--- a/src/lib/gui/source_editor.rs
+++ b/src/lib/gui/source_editor.rs
@@ -396,6 +396,7 @@ pub fn set(
         .h(selected_canvas_h)
         .y(selected_canvas_y.middle())
         .align_middle_x_of(ids.side_menu)
+        .parent(area.id)
         .set(ids.source_editor_selected_canvas, ui);
 
     let selected_canvas_kid_area = ui.kid_area_of(ids.source_editor_selected_canvas)
@@ -885,7 +886,12 @@ pub fn set(
                 };
             }
 
-            // Playback duration.
+            // Maximum playback duration.
+            //
+            // This represents:
+            //
+            // - The duration over which a source previewed via "One Shot" will play.
+            // - The maximum playback duration of a soundscape sound using this source.
             let label = duration_label(&realtime.duration);
             let min = 0.0;
             let max = utils::HR_MS;
@@ -1587,7 +1593,7 @@ pub fn set(
             // - If it is a looping WAV or a realtime source the max is some arbitrary limit.
             let skew = sources[&id].kind.playback_duration_skew();
             let max_duration = match sources[&id].kind {
-                audio::source::Kind::Realtime(_) => audio::source::MAX_PLAYBACK_DURATION,
+                audio::source::Kind::Realtime(ref realtime) => realtime.duration,
                 audio::source::Kind::Wav(ref wav) => match wav.should_loop {
                     true => audio::source::MAX_PLAYBACK_DURATION,
                     false => wav.duration.to_ms(audio::SAMPLE_RATE),


### PR DESCRIPTION
This commit fixes a bug where realtime sources appeared to ignore the
the specified playback duration range. In actuality, the realtime source
abided by its specified maximum duration specified under the "REALTIME
DATA" section. This parameter specifies the duration of oneshot previews
and also describes the maximum duration over which a realtime source
will be played.

This commit ensures that the playback duration range is bounded by the
realtime source duration parameter to make the behaviour more obvious.
It also corrects the progress bar surrounding sounds spawned via
realtime sources to show the correct duration.

Possibly related to #121.