### PR TITLE
Fixes bug where adding an installation could cause audio thread to panic

### DIFF
--- a/src/lib/audio/output.rs
+++ b/src/lib/audio/output.rs
@@ -456,7 +456,6 @@ pub fn render(mut model: Model, mut buffer: Buffer) -> (Model, Buffer) {
         // For each sound, request `buffer.len()` number of frames and sum them onto the
         // relevant output channels.
         for (&sound_id, sound) in sounds.iter_mut() {
-
             // Update the GUI with the position of the sound.
             let source_id = sound.source_id();
             let position = sound.position;
@@ -540,6 +539,10 @@ pub fn render(mut model: Model, mut buffer: Buffer) -> (Model, Buffer) {
             }
 
             // Mix the audio from the signal onto each of the output channels.
+            if speakers.is_empty() {
+                continue;
+            }
+
             for (i, channel_point) in sound.channel_points().enumerate() {
                 // Update the dbap_speakers buffer with their distances to this sound channel.
                 dbap_speakers.clear();
@@ -560,6 +563,11 @@ pub fn render(mut model: Model, mut buffer: Buffer) -> (Model, Buffer) {
                         let weight = speaker::dbap_weight(&sound.installations, &active.speaker.installations);
                         dbap_speakers.push(dbap::Speaker { distance, weight });
                     }
+                }
+
+                // If no speakers were found, skip this channel.
+                if dbap_speakers.is_empty() {
+                    continue;
                 }
 
                 // Update the speaker gains.

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -241,5 +241,4 @@ fn exit(app: &App, model: Model) {
 
     // Wait for the composer thread to finish.
     soundscape_thread.join().expect("failed to join the soundscape thread when exiting");
-
 }


### PR DESCRIPTION
This resulted in not being able to edit any of the GUI parameters for
thew newly created installation. The root of the cause was that, when
a new installation was created, the speaker count was reduced to 0. This
would cause the DBAP calculation to `panic!` as there must be at least
one speaker for the calculations to make any sense.

Closes #145.