### PR TITLE
Fix bug where removing a source could cause GUI to crash

### DIFF
--- a/src/lib/gui/mod.rs
+++ b/src/lib/gui/mod.rs
@@ -169,7 +169,7 @@ type ControlLog = Log<osc::input::Control>;
 #[derive(Default)]
 struct AudioMonitor {
     master_peak: f32,
-    active_sounds: ActiveSoundMap,
+    pub active_sounds: ActiveSoundMap,
     speakers: FxHashMap<audio::speaker::Id, ChannelLevels>,
 }
 

--- a/src/lib/gui/source_editor.rs
+++ b/src/lib/gui/source_editor.rs
@@ -60,6 +60,7 @@ pub fn set(
     let Gui {
         ref mut ui,
         ref mut ids,
+        ref mut audio_monitor,
         channels,
         sound_id_gen,
         state:
@@ -292,6 +293,9 @@ pub fn set(
                     source_editor.selected = None;
                 }
             }
+
+            // Remove any monitored sounds using this source ID.
+            audio_monitor.active_sounds.retain(|_, s| s.source_id != remove_id);
 
             // Remove the local copy.
             sources.remove(&remove_id);


### PR DESCRIPTION
This was due to an issue where the GUI would still try to preview active sounds that used this source. This has been fixed by ensuring that all monitored sounds spawned via the removed source are cleared.