### PR TITLE
Clear all sounds from source when switching from SCAPE to NONE

### DIFF
--- a/src/lib/audio/output.rs
+++ b/src/lib/audio/output.rs
@@ -378,6 +378,22 @@ impl Model {
         count
     }
 
+    /// Remove all sounds that were spawned via the source with the given `Id`.
+    ///
+    /// Returns the number of sounds that were updated.
+    pub fn remove_sounds_with_source(&mut self, id: &source::Id) -> usize {
+        let mut count = 0;
+        self.sounds.retain(|_, ref s| {
+            if s.source_id() == *id {
+                count += 1;
+                false
+            } else {
+                true
+            }
+        });
+        count
+    }
+
     /// Removes the sound and sends an `End` active sound message to the GUI.
     ///
     /// Returns `false` if the sound did not exist

--- a/src/lib/gui/source_editor.rs
+++ b/src/lib/gui/source_editor.rs
@@ -526,11 +526,23 @@ pub fn set(
                         }).expect("soundscape was closed");
                     },
 
-                    // If it is no longer a soundscape, remove it from the soundscape thread.
+                    // If it is no longer a soundscape.
                     (Some(Role::Soundscape(_)), _) => {
-                        channels.soundscape.send(move |soundscape| {
-                            soundscape.remove_source(&id);
-                        }).expect("soundscape was closed");
+                        // Remove the source from the soundscape.
+                        channels
+                            .soundscape
+                            .send(move |soundscape| {
+                                soundscape.remove_source(&id);
+                            })
+                            .expect("soundscape was closed");
+
+                        // Remove all sounds with this source from the audio output thread.
+                        channels
+                            .audio_output
+                            .send(move |audio| {
+                                audio.remove_sounds_with_source(&id);
+                            })
+                            .expect("soundscape was closed");
                     },
 
                     _ => (),


### PR DESCRIPTION
Previously active sounds were not cleared from the audio output thread
when a source would switch from SCAPE to a different role. This fixes
the bug by clearing all sounds that were spawned by the source.

Closes #152.