### PR TITLE
[macOS] Use app proxy to only wakeup event loop only when necessary

### DIFF
--- a/src/lib/gui/monitor.rs
+++ b/src/lib/gui/monitor.rs
@@ -65,9 +65,12 @@ pub fn spawn(app_proxy: nannou::app::Proxy) -> io::Result<Spawned> {
                 for msg in msgs.drain(..) {
                     match gui_tx.send(msg) {
                         Ok(()) => {
-                            if app_proxy.wakeup().is_err() {
-                                eprintln!("audio_monitor proxy could not wakeup app");
-                                break 'run;
+                            // Proxy is currently buggy on linux so we only enable this for macos.
+                            if cfg!(target_os = "macos") {
+                                if app_proxy.wakeup().is_err() {
+                                    eprintln!("audio_monitor proxy could not wakeup app");
+                                    break 'run;
+                                }
                             }
                         },
                         Err(_) => break 'run,

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -65,10 +65,16 @@ where
 
 // Initialise the state of the application.
 fn model(app: &App) -> Model {
-    // Set the app to wait on events.
+    // If on macos, set the loop to wait mode.
     //
-    // We will wake it up if it is necessary to re-instantiate and redraw the GUI.
-    app.set_loop_mode(LoopMode::wait(3));
+    // We only do this on macos as the app::Proxy is still a bit buggy on linux and windows has not
+    // yet been tested.
+    if cfg!(target_os = "macos") {
+        // Set the app to wait on events.
+        //
+        // We will wake it up if it is necessary to re-instantiate and redraw the GUI.
+        app.set_loop_mode(LoopMode::wait(3));
+    }
 
     // Find the assets directory.
     let assets = app.assets_path()


### PR DESCRIPTION
Gate waiting event loop and app proxy usage behind macos flag

The waiting loop only works reliably on macos at the moment, and it is
important that macos has access to it as it will run significantly more
efficiently over its long-term use in the exhibition.