### PR TITLE
Ensure that program closes properly if thread communication fails

### DIFF
--- a/src/lib/audio/sound.rs
+++ b/src/lib/audio/sound.rs
@@ -266,7 +266,7 @@ pub fn spawn_from_wav(
         .send(move |audio| {
             audio.insert_sound(id, output_active_sound);
         })
-        .ok();
+        .expect("failed to send new sound to audio output thread");
 
     handle
 }
@@ -384,14 +384,14 @@ pub fn spawn_from_realtime(
                 .or_insert_with(Vec::new)
                 .push(input_active_sound);
         })
-        .ok();
+        .expect("failed to send new realtime input sound to audio input thread");
 
     // Send the active sound to the audio input thread.
     audio_output
         .send(move |audio| {
             audio.insert_sound(id, output_active_sound);
         })
-        .ok();
+        .expect("failed to send new sound to audio output thread");
 
     handle
 }
@@ -487,7 +487,8 @@ impl IdGenerator {
     }
 
     pub fn generate_next(&self) -> Id {
-        let mut next = self.next.lock().unwrap();
+        let mut next = self.next.lock()
+            .expect("failed to acquire mutex for generating new `sound::Id`");
         let id = *next;
         *next = Id(id.0.wrapping_add(1));
         id

--- a/src/lib/gui/master.rs
+++ b/src/lib/gui/master.rs
@@ -97,9 +97,12 @@ pub fn set(last_area_id: widget::Id, gui: &mut Gui, project: &mut Project) -> wi
         master.volume = new_volume;
 
         // Update the audio output thread's master volume.
-        channels.audio_output.send(move |audio| {
-            audio.master_volume = new_volume;
-        }).ok();
+        channels
+            .audio_output
+            .send(move |audio| {
+                audio.master_volume = new_volume;
+            })
+            .expect("failed to send updated master volume to audio output thread");
     }
 
     // The realtime source latency slider.
@@ -124,7 +127,7 @@ pub fn set(last_area_id: widget::Id, gui: &mut Gui, project: &mut Project) -> wi
             .send(move |soundscape| {
                 soundscape.realtime_source_latency = Ms(new_latency);
             })
-            .ok();
+            .expect("failed to send updated realtime source latency volume to soundscape thread");
     }
 
     // The master volume slider.
@@ -143,9 +146,12 @@ pub fn set(last_area_id: widget::Id, gui: &mut Gui, project: &mut Project) -> wi
         master.dbap_rolloff_db = new_rolloff;
 
         // Update the audio output thread's rolloff.
-        channels.audio_output.send(move |audio| {
-            audio.dbap_rolloff_db = new_rolloff;
-        }).ok();
+        channels
+            .audio_output
+            .send(move |audio| {
+                audio.dbap_rolloff_db = new_rolloff;
+            })
+            .expect("failed to send updated DBAP rolloff to audio output thread");
     }
 
     area.id

--- a/src/lib/gui/mod.rs
+++ b/src/lib/gui/mod.rs
@@ -387,7 +387,7 @@ impl Model {
                     channels
                         .audio_output
                         .send(move |audio| audio.master_volume = volume)
-                        .ok();
+                        .expect("failed to send updated master volume to audio output thread");
                 },
 
                 &osc::input::Control::SourceVolume(ref source_volume) => {
@@ -418,7 +418,7 @@ impl Model {
                         .send(move |soundscape| {
                             soundscape.update_source(&id, |source| source.volume = volume);
                         })
-                        .expect("could not update source volume on soundscape");
+                        .expect("failed to send updated source volume to soundscape thread");
 
                     // Update the audio output copies.
                     channels
@@ -428,15 +428,21 @@ impl Model {
                                 sound.volume = volume;
                             });
                         })
-                        .ok();
+                        .expect("failed to send updated source volume to audio output thread");
                 }
 
                 &osc::input::Control::PlaySoundscape => {
-                    channels.soundscape.play().ok();
+                    channels
+                        .soundscape
+                        .play()
+                        .expect("failed to send `Play` message to soundscape thread");
                 }
 
                 &osc::input::Control::PauseSoundscape => {
-                    channels.soundscape.pause().ok();
+                    channels
+                        .soundscape
+                        .pause()
+                        .expect("failed to send `Pause` message to soundscape thread");
                 }
             }
 
@@ -1442,7 +1448,7 @@ fn set_widgets(
                         .send(move |audio| {
                             audio.insert_speaker(speaker_id, speaker_clone);
                         })
-                        .ok();
+                        .expect("failed to send updated speaker to audio output thread");
 
                     // Update the soundscape copy.
                     channels
@@ -1450,7 +1456,7 @@ fn set_widgets(
                         .send(move |soundscape| {
                             soundscape.update_speaker(&speaker_id, |s| s.point = new_p);
                         })
-                        .ok();
+                        .expect("failed to send speaker update to soundscape thread");
                 }
                 new_p
             };
@@ -1575,7 +1581,7 @@ fn set_widgets(
                                         s.position.point = new_p;
                                     });
                                 })
-                                .ok();
+                                .expect("failed to send sound position to audio output thread");
                         }
 
                         audio::sound::Position {

--- a/src/lib/gui/project_editor.rs
+++ b/src/lib/gui/project_editor.rs
@@ -317,19 +317,19 @@ pub fn set(
             channels
                 .soundscape
                 .send(move |soundscape| soundscape.clear_project_specific_data())
-                .ok();
+                .expect("failed to send `clear_project_specific_data` message to soundscape thread");
             channels
                 .audio_input
                 .send(move |audio| audio.clear_project_specific_data())
-                .ok();
+                .expect("failed to send `clear_project_specific_data` message to audio input thread");
             channels
                 .audio_output
                 .send(move |audio| audio.clear_project_specific_data())
-                .ok();
+                .expect("failed to send `clear_project_specific_data` message to audio output thread");
             channels
                 .osc_out_msg_tx
                 .send(osc::output::Message::ClearProjectSpecificData)
-                .ok();
+                .expect("failed to send `ClearProjectSpecificData` message to OSC output thread");
         }
     }
 

--- a/src/lib/gui/soundscape_editor.rs
+++ b/src/lib/gui/soundscape_editor.rs
@@ -107,9 +107,15 @@ pub fn set(
         .set(ids.soundscape_editor_is_playing, ui)
     {
         if new_is_playing {
-            channels.soundscape.play().ok();
+            channels
+                .soundscape
+                .play()
+                .expect("failed to send play command to soundscape thread");
         } else {
-            channels.soundscape.pause().ok();
+            channels
+                .soundscape
+                .pause()
+                .expect("failed to send pause command to soundscape thread");
         }
     }
 
@@ -280,9 +286,12 @@ pub fn set(
         soundscape_groups.remove(&id);
 
         // Remove this group from any sources on the soundscape thread.
-        channels.soundscape.send(move |soundscape| {
-            soundscape.remove_group(&id);
-        }).ok();
+        channels
+            .soundscape
+            .send(move |soundscape| {
+                soundscape.remove_group(&id);
+            })
+            .expect("failed to remove soundscape group from soundscape thread");
     }
 
     ////////////////////
@@ -400,11 +409,14 @@ pub fn set(
         };
 
         // Update the soundscape copy.
-        channels.soundscape.send(move |soundscape| {
-            soundscape.update_group(&id, |group| {
-                group.occurrence_rate = new_rate;
-            });
-        }).ok();
+        channels
+            .soundscape
+            .send(move |soundscape| {
+                soundscape.update_group(&id, |group| {
+                    group.occurrence_rate = new_rate;
+                });
+            })
+            .expect("failed to send updated occurrence rate to soundscape thread");
     }
 
     /////////////////////////
@@ -448,11 +460,14 @@ pub fn set(
         };
 
         // Update the soundscape copy.
-        channels.soundscape.send(move |soundscape| {
-            soundscape.update_group(&id, |group| {
-                group.simultaneous_sounds = new_rate;
-            });
-        }).ok();
+        channels
+            .soundscape
+            .send(move |soundscape| {
+                soundscape.update_group(&id, |group| {
+                    group.simultaneous_sounds = new_rate;
+                });
+            })
+            .expect("failed to send updated simultaneous sounds constraint to soundscape thread");
     }
 
     area.id

--- a/src/lib/gui/speaker_editor.rs
+++ b/src/lib/gui/speaker_editor.rs
@@ -217,7 +217,7 @@ pub fn set(
                 .send(move |audio| {
                     audio.remove_speaker(speaker_id);
                 })
-                .ok();
+                .expect("failed to remove speaker from audio output thread");
 
             // Remove the soundscape copy.
             channels
@@ -225,7 +225,7 @@ pub fn set(
                 .send(move |soundscape| {
                     soundscape.remove_speaker(&speaker_id);
                 })
-                .ok();
+                .expect("failed to remove speaker from soundscape thread");
         }
     }
 
@@ -261,7 +261,7 @@ pub fn set(
                 .send(move |audio| {
                     audio.insert_speaker(id, speaker);
                 })
-                .ok();
+                .expect("failed to send speaker to audio output thread");
 
             // Update the soundscape copy.
             let soundscape_speaker = soundscape::Speaker::from_audio_speaker(&audio);
@@ -270,7 +270,7 @@ pub fn set(
                 .send(move |soundscape| {
                     soundscape.insert_speaker(id, soundscape_speaker);
                 })
-                .ok();
+                .expect("failed to send speaker to soundscape thread");
 
             // Update the local copy.
             let speaker = project::Speaker { name, audio };
@@ -363,7 +363,7 @@ pub fn set(
             .send(move |audio| {
                 audio.insert_speaker(id, speaker);
             })
-            .ok();
+            .expect("failed to send speaker to audio output thread");
 
         // If an existing speaker was assigned to `index`, swap it with the original
         // selection.
@@ -386,7 +386,7 @@ pub fn set(
                 .send(move |audio| {
                     audio.insert_speaker(other_id, other_speaker);
                 })
-                .ok();
+                .expect("failed to send speaker to audio output thread");
         }
     }
 
@@ -438,7 +438,7 @@ pub fn set(
             .send(move |audio| {
                 audio.insert_speaker_installation(id, installation);
             })
-            .ok();
+            .expect("failed to update speaker installation for audio output thread");
 
         // Update the soundscape copy.
         gui.channels
@@ -448,7 +448,7 @@ pub fn set(
                     speaker.installations.insert(installation);
                 });
             })
-            .ok();
+            .expect("failed to update speaker installations for soundscape thread");
     }
 
     // A scrollable list showing each of the assigned installations.
@@ -533,7 +533,7 @@ pub fn set(
             .send(move |audio| {
                 audio.remove_speaker_installation(id, &inst);
             })
-            .ok();
+            .expect("failed to remove installation from speaker on audio output thread");
 
         // Update the soundscape copy.
         gui.channels
@@ -543,7 +543,7 @@ pub fn set(
                     speaker.installations.remove(&inst);
                 });
             })
-            .ok();
+            .expect("failed to remove installation from speaker on soundscape thread");
     }
 
     area.id

--- a/src/lib/project/mod.rs
+++ b/src/lib/project/mod.rs
@@ -244,19 +244,19 @@ impl Project {
         channels
             .soundscape
             .send(move |soundscape| soundscape.clear_project_specific_data())
-            .ok();
+            .expect("failed to send `clear_project_specific_data` message to soundscape thread");
         channels
             .audio_input
             .send(move |audio| audio.clear_project_specific_data())
-            .ok();
+            .expect("failed to send `clear_project_specific_data` message to audio input thread");
         channels
             .audio_output
             .send(move |audio| audio.clear_project_specific_data())
-            .ok();
+            .expect("failed to send `clear_project_specific_data` message to audio output thread");
         channels
             .osc_out_msg_tx
             .send(osc::output::Message::ClearProjectSpecificData)
-            .ok();
+            .expect("failed to send `ClearProjectSpecificData` message to OSC output thread");
 
         // TODO: Consider updating config stuff here?
 
@@ -322,7 +322,7 @@ impl Project {
                 .send(move |soundscape| {
                     soundscape.insert_group(id, clone);
                 })
-                .ok();
+                .expect("failed to send soundscape group to soundscape thread");
         }
 
         // Speakers to the soundscape and audio output threads.
@@ -333,14 +333,14 @@ impl Project {
                 .send(move |audio| {
                     audio.insert_speaker(id, clone);
                 })
-                .ok();
+                .expect("failed to send speaker to audio output thread");
             let soundscape_speaker = soundscape::Speaker::from_audio_speaker(&speaker.audio);
             channels
                 .soundscape
                 .send(move |soundscape| {
                     soundscape.insert_speaker(id, soundscape_speaker);
                 })
-                .ok();
+                .expect("failed to send speaker to soundscape thread");
         }
 
         // Sources to the audio input and soundscape threads.
@@ -352,7 +352,7 @@ impl Project {
                     .send(move |audio| {
                         audio.sources.insert(id, clone);
                     })
-                    .ok();
+                    .expect("failed to send source to audio input thread");
             }
             if let Some(clone) = soundscape::Source::from_audio_source(&source) {
                 channels
@@ -360,7 +360,7 @@ impl Project {
                     .send(move |soundscape| {
                         soundscape.insert_source(id, clone);
                     })
-                    .ok();
+                    .expect("failed to send source to soundscape thread");
             }
         }
 

--- a/src/lib/soundscape/mod.rs
+++ b/src/lib/soundscape/mod.rs
@@ -1399,7 +1399,7 @@ fn tick(model: &mut Model, tick: Tick) {
                         sound.position = position;
                     });
                 })
-                .ok();
+                .expect("failed to send audio output thread updated sound position");
         }
     }
 


### PR DESCRIPTION
Currently it is possible for a thread to die and for the program to
continue running, despite not being able to successfully communicate
between threads. This can cause seemingly unrelated strange behaviour in
the GUI.

This commit makes sure that the program closes immediately with an error
message if a message cannot be sent across threads due to one of the
threads dying.

cc @freesig this should also make sure the program doesn't continue
running in a broken state if one of the threads panic and should allow
a keepalive script to immediately restart the server.