### PR TITLE
Fix bug where GUI would allow for specifying NGON with `0` sides

### DIFF
--- a/src/lib/gui/source_editor.rs
+++ b/src/lib/gui/source_editor.rs
@@ -2328,7 +2328,7 @@ pub fn set(
 
                     let min = ngon.vertices.min as f64;
                     let max = ngon.vertices.max as f64;
-                    let total_min = 0.0;
+                    let total_min = 1.0;
                     let total_max = audio::source::movement::MAX_VERTICES as f64;
                     let label = format!("{} to {} vertices", min, max);
                     for (edge, value) in range_slider(min, max, total_min, total_max)


### PR DESCRIPTION
This fixes an issue where the source editor GUI would allow the user to
select `0` as the number of sides of the equilateral NGON. This would
cause the program to `panic!` when the value was used as the divisor in
a remainder calculation a little later on. This has been addressed by
bounding the slider to a minimum number of sides of "1" (in which case
the sound will stay centred at the NGON's position and not move - this
behaviour is unchanged).

Closes #188.