### PR TITLE
wip: make this work in the new world

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "audio_server"
 version = "0.1.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
+resolver = "2"
+edition = "2021"
 
 [profile.release]
 debug = true
@@ -15,21 +17,23 @@ name = "audio_server"
 path = "src/lib/lib.rs"
 
 [dependencies]
-conrod_core = "0.69"
-conrod_derive = "0.69"
-crossbeam = "0.3"
+conrod_core = "0.76.1"
+conrod_derive = "0.76.1"
+crossbeam = "0.8.1"
 custom_derive = "0.1"
+dasp = { version = "0.11.0", features = ["all"] }
 fxhash = "0.2"
 hound = "3.3"
 mindtree_utils = "0.4"
 newtype_derive = "0.1"
-nannou = "0.13"
-nannou_audio = "0.2"
-nannou_osc = "0.1"
+nannou = "0.18.1"
+nannou_audio = "0.18.0"
+nannou_conrod = "0.18.0"
+nannou_osc = "0.18.0"
 num_cpus = "1.8"
-pitch_calc = "0.11"
-rand_xorshift = "0.2"
-rustfft = "2.0"
+pitch_calc = "0.12.0"
+rand_xorshift = "0.3.0"
+rustfft = "6.0.1"
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = "1.0"
@@ -40,4 +44,4 @@ walkdir = "2"
 
 [features]
 asio = ["nannou_audio/asio"]
-test_with_stereo = [] # Compile with this feature to set the max i/o channels as `2`.
+test_with_stereo = []        # Compile with this feature to set the max i/o channels as `2`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 resolver = "2"
 edition = "2021"
+include = ["src/**/*", "README.md"]
 
 [profile.release]
 debug = true

--- a/assets/config.json
+++ b/assets/config.json
@@ -13,9 +13,24 @@
       0,
       0,
       0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
       0
-    ]
+    ],
+    "proximity_limit_2": 49.0
   },
-  "selected_project_slug": "my-project-1",
-  "cpu_saving_mode": false
+  "selected_project_slug": "my-project",
+  "cpu_saving_mode": false,
+  "target_input_device_name": "",
+  "target_output_device_name": ""
 }

--- a/src/lib/audio/dbap.rs
+++ b/src/lib/audio/dbap.rs
@@ -1,6 +1,6 @@
 //! An implementation of Distance-Based Amplitude Panning as published by Trond Lossius, 2009.
 
-use nannou::geom::Point2;
+use nannou::glam::DVec2 as Point2;
 
 #[derive(Copy, Clone, Debug)]
 pub struct Speaker {
@@ -25,9 +25,9 @@ pub struct SpeakerGains<'a> {
 /// speaker only."
 ///
 /// A non-zero blur will ensure that the distance is greater than `0.0` and that we never divide by 0.0.
-pub fn blurred_distance_2(source: Point2<f64>, speaker: Point2<f64>, blur: f64) -> f64 {
-    let x = speaker.x - source.x;
-    let y = speaker.y - source.y;
+pub fn blurred_distance_2(source: Point2, speaker: Point2, blur: f64) -> f64 {
+    let x: f64 = speaker.x - source.x;
+    let y: f64 = speaker.y - source.y;
     (x * x + y * y + blur * blur).max(::std::f64::EPSILON)
 }
 
@@ -105,17 +105,15 @@ fn k_coefficient(a: f64, speakers: &[Speaker]) -> f64 {
 
 #[test]
 fn speaker_gains() {
-    use nannou::prelude::*;
-
-    let src = pt2(5.0, 5.0);
-    let speaker = |v: Point2<f64>, w| Speaker {
+    let src = Point2::new(5.0, 5.0);
+    let speaker = |v: Point2, w| Speaker {
         distance: v.distance(src),
         weight: w,
     };
-    let a = speaker(pt2(0.0, 0.0), 1.0);
-    let b = speaker(pt2(10.0, 0.0), 1.0);
-    let c = speaker(pt2(10.0, 10.0), 1.0);
-    let d = speaker(pt2(0.0, 10.0), 1.0);
+    let a = speaker(Point2::new(0.0, 0.0), 1.0);
+    let b = speaker(Point2::new(10.0, 0.0), 1.0);
+    let c = speaker(Point2::new(10.0, 10.0), 1.0);
+    let d = speaker(Point2::new(0.0, 10.0), 1.0);
     let spkrs = vec![a, b, c, d];
     let r = 6.0; // free-field rolloff db.
     let gains = SpeakerGains::new(&spkrs, r).collect::<Vec<_>>();

--- a/src/lib/audio/detection.rs
+++ b/src/lib/audio/detection.rs
@@ -263,7 +263,7 @@ impl Model {
         let in_window = [Complex::<f32>::zero(); FFT_WINDOW_LEN];
         let out_window = [Complex::<f32>::zero(); FFT_WINDOW_LEN];
         let fft = Fft::new(in_window, out_window);
-        let inverse = false;
+        let _inverse = false;
         let fft_planner = fft::Planner::new();
         let fft_direction = rustfft::FftDirection::Inverse;
 

--- a/src/lib/audio/detection.rs
+++ b/src/lib/audio/detection.rs
@@ -6,16 +6,17 @@
 //! - RMS and Peak per Speaker channel.
 //! - FFT and avg RMS and Peak per installation.
 
-use audio::{MAX_CHANNELS, FRAMES_PER_BUFFER};
-use audio::{fft, sound, speaker};
-use audio::detector::{EnvDetector, Fft, FftDetector, FFT_WINDOW_LEN};
-use crossbeam::sync::SegQueue;
+use super::detector::{EnvDetector, Fft, FftDetector, FFT_WINDOW_LEN};
+use super::{fft, sound, speaker};
+use super::{FRAMES_PER_BUFFER, MAX_CHANNELS};
+use crate::gui;
+use crate::installation;
+use crate::osc;
+use crossbeam::queue::SegQueue;
 use fxhash::{FxHashMap, FxHashSet};
-use gui;
-use installation;
-use osc;
 use rustfft::num_complex::Complex;
 use rustfft::num_traits::Zero;
+use rustfft::FftDirection;
 use std::ops;
 use std::sync::{Arc, Mutex};
 use std::{thread, time};
@@ -141,6 +142,8 @@ pub struct Model {
 
     /// The FFT planner used to prepare the FFT calculations and share data between them.
     fft_planner: fft::Planner,
+    /// The FFT Planner direction
+    fft_direction: FftDirection,
     /// The FFT to re-use by each of the `Detector`s.
     fft: Fft,
     /// A buffer for retrieving the frequency amplitudes from the `fft`.
@@ -209,15 +212,14 @@ impl Handle {
 
     /// Pop the next available sound buffer for use off the queue.
     pub fn pop_sound_buffer(&self) -> Vec<f32> {
-        let mut buffer = self.sound_buffer_rx.try_pop().unwrap_or_else(Vec::new);
+        let mut buffer = self.sound_buffer_rx.pop().unwrap_or_else(Vec::new);
         buffer.clear();
         buffer
     }
 
     /// Pop the next available output buffer for use off the queue.
     pub fn pop_output_buffer(&self) -> (Vec<f32>, OutputInfo) {
-        let (mut buffer, mut info) = self.output_buffer_rx.try_pop()
-            .unwrap_or_else(Default::default);
+        let (mut buffer, mut info) = self.output_buffer_rx.pop().unwrap_or_else(Default::default);
         buffer.clear();
         info.clear();
         (buffer, info)
@@ -262,7 +264,8 @@ impl Model {
         let out_window = [Complex::<f32>::zero(); FFT_WINDOW_LEN];
         let fft = Fft::new(in_window, out_window);
         let inverse = false;
-        let fft_planner = fft::Planner::new(inverse);
+        let fft_planner = fft::Planner::new();
+        let fft_direction = rustfft::FftDirection::Inverse;
 
         // A buffer for retrieving the frequency amplitudes from the `fft`.
         let fft_frequency_amplitudes_2 = Box::new([0.0; FFT_WINDOW_LEN / 2]);
@@ -283,6 +286,7 @@ impl Model {
             fft_planner,
             fft,
             fft_frequency_amplitudes_2,
+            fft_direction,
         }
     }
 }
@@ -321,12 +325,23 @@ pub fn spawn(
     let thread = thread::Builder::new()
         .name("audio_detection".into())
         .spawn(move || {
-            run(gui_audio_monitor_msg_tx, osc_output_msg_tx, rx, sound_buffer_tx, output_buffer_tx);
+            run(
+                gui_audio_monitor_msg_tx,
+                osc_output_msg_tx,
+                rx,
+                sound_buffer_tx,
+                output_buffer_tx,
+            );
         })
         .unwrap();
     let thread = Arc::new(Mutex::new(Some(thread)));
 
-    Handle { tx, thread, sound_buffer_rx, output_buffer_rx }
+    Handle {
+        tx,
+        thread,
+        sound_buffer_rx,
+        output_buffer_rx,
+    }
 }
 
 /// The main loop for the detection thread.
@@ -363,19 +378,18 @@ fn run(
 
     // Begin the loop.
     loop {
-        let msg = match rx.try_pop() {
+        let msg = match rx.pop() {
             // If there are no messages waiting, sleep for a tiny bit to avoid rinsing cpu.
             None => {
                 thread::sleep(time::Duration::from_millis(1));
                 continue;
-            },
+            }
             Some(msg) => msg,
         };
 
         match msg {
             // Insert the new sound into the map.
             Message::AddSound(sound_id, channels) => {
-
                 let sound = new_sound(channels);
                 model.sounds.insert(sound_id, sound);
 
@@ -389,7 +403,7 @@ fn run(
                         model.num_active_sound_buffers += 1;
                     }
                 }
-            },
+            }
 
             // Update the detection for the sound with the given `Id`.
             Message::UpdateSound(sound_id, buffer) => {
@@ -406,7 +420,7 @@ fn run(
                         let Buffer { samples, .. } = buffer;
                         sound_buffer_tx.push(samples);
                         continue;
-                    },
+                    }
                     Some(sound) => sound,
                 };
 
@@ -432,36 +446,38 @@ fn run(
                     let msg = gui::AudioMonitorMessage::ActiveSound(sound_id, sound_msg);
                     gui_audio_monitor_msg_tx.push(msg);
                 }
-            },
+            }
 
             // The sound has ended and its state should be removed.
             Message::RemoveSound(sound_id) => {
                 model.sounds.remove(&sound_id);
-            },
+            }
 
             // Initialise detection state for the given installation if it does not already exit.
             Message::AddInstallation(installation_id, computers) => {
-                let installation = model
-                    .installations
-                    .entry(installation_id)
-                    .or_insert_with(|| {
-                        let speaker_analyses = Vec::with_capacity(MAX_CHANNELS);
-                        let summed_samples_of_all_channels = Vec::with_capacity(FRAMES_PER_BUFFER);
-                        let fft_detector = FftDetector::new();
-                        Installation {
-                            speaker_analyses,
-                            summed_samples_of_all_channels,
-                            fft_detector,
-                            computers,
-                        }
-                    });
+                let installation =
+                    model
+                        .installations
+                        .entry(installation_id)
+                        .or_insert_with(|| {
+                            let speaker_analyses = Vec::with_capacity(MAX_CHANNELS);
+                            let summed_samples_of_all_channels =
+                                Vec::with_capacity(FRAMES_PER_BUFFER);
+                            let fft_detector = FftDetector::new();
+                            Installation {
+                                speaker_analyses,
+                                summed_samples_of_all_channels,
+                                fft_detector,
+                                computers,
+                            }
+                        });
                 installation.computers = computers;
-            },
+            }
 
             // Remove the given detection state for the given installation.
             Message::RemoveInstallation(installation_id) => {
                 model.installations.remove(&installation_id);
-            },
+            }
 
             // Perform analysis for the output buffer.
             //
@@ -475,6 +491,7 @@ fn run(
                     ref mut installations,
                     ref mut fft,
                     ref mut fft_planner,
+                    fft_direction,
                     ref mut fft_frequency_amplitudes_2,
                     ref gui_audio_monitor_msg_tx,
                     ref osc_output_msg_tx,
@@ -484,7 +501,9 @@ fn run(
                 } = model;
 
                 let Buffer { samples, channels } = buffer;
-                let OutputInfo { speakers: speaker_infos } = info;
+                let OutputInfo {
+                    speakers: speaker_infos,
+                } = info;
 
                 // The number of frames in the buffer.
                 let len_frames = samples.len() / channels;
@@ -492,8 +511,13 @@ fn run(
                 // Initialise the detection state for each installation.
                 for installation in installations.values_mut() {
                     installation.speaker_analyses.clear();
-                    installation.summed_samples_of_all_channels.resize(len_frames, 0.0);
-                    installation.summed_samples_of_all_channels.iter_mut().for_each(|s| *s = 0.0);
+                    installation
+                        .summed_samples_of_all_channels
+                        .resize(len_frames, 0.0);
+                    installation
+                        .summed_samples_of_all_channels
+                        .iter_mut()
+                        .for_each(|s| *s = 0.0);
                 }
 
                 // For each speaker, feed its amplitude into its detectors.
@@ -504,9 +528,9 @@ fn run(
                     }
 
                     // Retrieve the detector state for the speaker.
-                    let state = speakers
-                        .entry(id)
-                        .or_insert_with(|| Speaker { env_detector: EnvDetector::new() });
+                    let state = speakers.entry(id).or_insert_with(|| Speaker {
+                        env_detector: EnvDetector::new(),
+                    });
 
                     // Only update the envelope detector if CPU saving is not enabled.
                     let mut rms = 0.0;
@@ -594,6 +618,7 @@ fn run(
                             fft_planner,
                             fft,
                             &mut fft_frequency_amplitudes_2[..],
+                            fft_direction,
                         );
 
                         // Retrieve the LMH representation.
@@ -631,10 +656,13 @@ fn run(
 
                     // Sort the speakers by channel index as the OSC output thread assumes that
                     // speakers are in order of index.
-                    installation.speaker_analyses.sort_by(|a, b| a.index.cmp(&b.index));
+                    installation
+                        .speaker_analyses
+                        .sort_by(|a, b| a.index.cmp(&b.index));
 
                     // Collect the speaker data.
-                    let speakers = installation.speaker_analyses
+                    let speakers = installation
+                        .speaker_analyses
                         .drain(..)
                         .map(|s| osc::output::Speaker {
                             rms: s.rms,
@@ -656,25 +684,25 @@ fn run(
                 }
 
                 // Send buffer and output info back to audio thread for re-use.
-                let info = OutputInfo { speakers: speaker_infos };
+                let info = OutputInfo {
+                    speakers: speaker_infos,
+                };
                 output_buffer_tx.push((samples, info));
-            },
+            }
 
             // Clear all project-specific detection data.
             Message::ClearProjectSpecificData => {
                 model.sounds.clear();
                 model.speakers.clear();
                 model.installations.clear();
-            },
+            }
 
             Message::CpuSavingEnabled(enabled) => {
                 model.cpu_saving_enabled = enabled;
             }
 
             // Exit the loop as the app has exited.
-            Message::Exit => {
-                break
-            },
+            Message::Exit => break,
         }
     }
 }

--- a/src/lib/audio/detector.rs
+++ b/src/lib/audio/detector.rs
@@ -2,9 +2,11 @@
 //!
 //! Detects RMS and Peak envelopes.
 
-use audio;
-use nannou_audio::sample::{self, ring_buffer};
-use rustfft::num_complex::Complex;
+use dasp::{self as sample};
+use rustfft::{num_complex::Complex, FftDirection};
+use sample::ring_buffer;
+
+use super::SAMPLE_RATE;
 
 // The frame type used within the detectors.
 type FrameType = [f32; 1];
@@ -30,7 +32,7 @@ pub type FftPlanner = super::fft::Planner;
 // RMS is monitored for visualisation, so we want a window size roughly the duration of one frame.
 //
 // A new visual frame is displayed roughly 60 times per second compared to 44_100 audio frames.
-const WINDOW_SIZE: usize = audio::SAMPLE_RATE as usize / 60;
+const WINDOW_SIZE: usize = SAMPLE_RATE as usize / 60;
 
 // The number of frames used to smooth the attack/release of the RMS detection.
 const RMS_ATTACK_FRAMES: f32 = 0.0;
@@ -42,7 +44,7 @@ const PEAK_RELEASE_FRAMES: f32 = WINDOW_SIZE as f32 / 8.0;
 pub const FFT_WINDOW_LEN: usize = 512;
 
 /// The step between each frequency bin is equal to `samplerate / 2 * windowlength`.
-pub const FFT_BIN_STEP_HZ: f64 = audio::SAMPLE_RATE / (2.0 * FFT_WINDOW_LEN as f64);
+pub const FFT_BIN_STEP_HZ: f64 = super::SAMPLE_RATE / (2.0 * FFT_WINDOW_LEN as f64);
 
 /// An envelope detector for a single channel.
 ///
@@ -113,7 +115,13 @@ impl FftDetector {
         fft_planner: &mut FftPlanner,
         fft: &mut Fft,
         freq_amps: &mut [f32],
+        direction: FftDirection,
     ) {
-        fft.process(fft_planner, self.fft_samples.iter().cloned(), freq_amps);
+        fft.process(
+            fft_planner,
+            self.fft_samples.iter().cloned(),
+            freq_amps,
+            direction,
+        );
     }
 }

--- a/src/lib/audio/input.rs
+++ b/src/lib/audio/input.rs
@@ -2,12 +2,12 @@
 //!
 //! The input stream has a number of `Source`s that read from one or more of the stream's channels.
 
-use audio::source;
+use crate::audio::source;
 use fxhash::FxHashMap;
 use nannou_audio::Buffer;
 use std::cmp;
-use std::sync::Arc;
 use std::sync::atomic::{self, AtomicBool};
+use std::sync::Arc;
 
 /// Simplified type alias for the nannou audio input stream used by the audio server.
 pub type Stream = nannou_audio::Stream<Model>;
@@ -106,17 +106,17 @@ pub fn capture(model: &mut Model, buffer: &Buffer) {
             }
 
             // Retrieve the empty buffer to use for sending samples.
-            let mut samples = match sound.buffer_rx.try_pop() {
+            let mut samples = match sound.buffer_rx.pop() {
                 // This branch should never be hit but is here just in case.
                 None => {
                     let samples_len = frames_to_take * realtime.channels.len();
                     Vec::with_capacity(samples_len)
-                },
+                }
                 // There should always be a buffer waiting in this channel.
                 Some(mut samples) => {
                     samples.clear();
                     samples
-                },
+                }
             };
 
             // Get the channel range and ensure it is no greater than the buffer len.

--- a/src/lib/audio/mod.rs
+++ b/src/lib/audio/mod.rs
@@ -1,4 +1,4 @@
-use metres::Metres;
+use crate::metres::Metres;
 use nannou_audio::{Device, Host};
 use time_calc::Ms;
 
@@ -49,9 +49,9 @@ pub const DEFAULT_DBAP_ROLLOFF_DB: f64 = 4.0;
 pub const DISTANCE_BLUR: f64 = 0.01;
 
 /// The initial, default proximity limit.
-pub const DEFAULT_PROXIMITY_LIMIT: Metres = Metres(7.0);
+pub const DEFAULT_PROXIMITY_LIMIT: Metres = 7.0;
 /// Proximity limit squared for efficientcy efficiency.
-pub const DEFAULT_PROXIMITY_LIMIT_2: Metres = Metres(DEFAULT_PROXIMITY_LIMIT.0 * DEFAULT_PROXIMITY_LIMIT.0);
+pub const DEFAULT_PROXIMITY_LIMIT_2: Metres = DEFAULT_PROXIMITY_LIMIT * DEFAULT_PROXIMITY_LIMIT;
 
 /// Retrieve the desired audio host for the system.
 ///

--- a/src/lib/audio/output.rs
+++ b/src/lib/audio/output.rs
@@ -3,24 +3,24 @@
 //! The render function is passed to `nannou::App`'s build output stream method and describes how
 //! audio should be rendered to the output.
 
-use audio::{DISTANCE_BLUR, FRAMES_PER_BUFFER, MAX_CHANNELS, MAX_SOUNDS};
-use audio::{Sound, Speaker};
-use audio::{dbap, detection, source, sound, speaker};
+use crate::audio::{dbap, detection, sound, source, speaker};
+use crate::audio::{Sound, Speaker};
+use crate::audio::{DISTANCE_BLUR, FRAMES_PER_BUFFER, MAX_CHANNELS, MAX_SOUNDS};
+use crate::gui;
+use crate::installation;
+use crate::metres::Metres;
+use crate::osc;
+use crate::soundscape;
+use crate::utils;
 use fxhash::{FxHashMap, FxHashSet};
-use gui;
-use installation;
-use metres::Metres;
 use nannou_audio::Buffer;
-use nannou::geom::Point2;
-use nannou::math::MetricSpace;
-use osc;
-use soundscape;
 use std;
 use std::ops::{self, Deref, DerefMut};
-use std::sync::{atomic, mpsc, Arc};
 use std::sync::atomic::AtomicUsize;
+use std::sync::{atomic, mpsc, Arc};
 use time_calc::Samples;
-use utils;
+
+type Point2 = nannou::glam::DVec2;
 
 /// Simplified type alias for the nannou audio output stream used by the audio server.
 pub type Stream = nannou_audio::Stream<Model>;
@@ -98,7 +98,7 @@ impl ActiveSound {
             (Some(Samples(remaining)), Some(Samples(total))) => {
                 let current_frame = total - remaining;
                 Some(current_frame as f64 / total as f64)
-            },
+            }
             _ => None,
         };
         normalised_progress
@@ -194,7 +194,6 @@ pub struct Model {
     /// The current value of proximity limit. The limit in meters
     /// for a speaker to be considered in the dbap calculations
     pub proximity_limit_2: Metres,
-
 }
 
 struct Channels {
@@ -346,7 +345,8 @@ impl Model {
 
     /// Inserts the speaker and sends an `Add` message to the GUI.
     pub fn insert_speaker(&mut self, id: speaker::Id, speaker: Speaker) -> Option<Speaker> {
-        let old_speaker = self.speakers
+        let old_speaker = self
+            .speakers
             .remove(&id)
             .map(|ActiveSpeaker { speaker }| speaker);
         let speaker = ActiveSpeaker { speaker };
@@ -359,7 +359,8 @@ impl Model {
 
     /// Removes the speaker and sends a `Removed` message to the GUI.
     pub fn remove_speaker(&mut self, id: speaker::Id) -> Option<Speaker> {
-        let removed = self.speakers
+        let removed = self
+            .speakers
             .remove(&id)
             .map(|ActiveSpeaker { speaker }| speaker);
         if removed.is_some() {
@@ -379,7 +380,11 @@ impl Model {
     }
 
     /// Removes the installation from the speaker with the given `speaker::Id`.
-    pub fn remove_speaker_installation(&mut self, id: speaker::Id, inst: &installation::Id) -> bool {
+    pub fn remove_speaker_installation(
+        &mut self,
+        id: speaker::Id,
+        inst: &installation::Id,
+    ) -> bool {
         self.speakers
             .get_mut(&id)
             .map(|active| active.speaker.installations.remove(inst))
@@ -419,7 +424,7 @@ impl Model {
             Some(active) => {
                 update(&mut active.sound);
                 true
-            },
+            }
         }
     }
 
@@ -442,7 +447,9 @@ impl Model {
     ///
     /// Returns the number of sounds that were updated.
     pub fn remove_sounds_with_source(&mut self, id: &source::Id) -> usize {
-        let ids: Vec<_> = self.sounds.iter()
+        let ids: Vec<_> = self
+            .sounds
+            .iter()
             .filter(|&(_, s)| s.source_id() == *id)
             .map(|(&id, _)| id)
             .collect();
@@ -486,7 +493,11 @@ impl Model {
         self.soloed.clear();
         self.speakers.clear();
 
-        let Model { ref mut sounds, ref channels, .. } = *self;
+        let Model {
+            ref mut sounds,
+            ref channels,
+            ..
+        } = *self;
         for (sound_id, sound) in sounds.drain() {
             // Notify threads of sound removal.
             channels.notify_sound_end(sound_id, sound);
@@ -505,7 +516,9 @@ impl Channels {
         let update = move |soundscape: &mut soundscape::Model| {
             soundscape.remove_active_sound(&id);
         };
-        self.soundscape_tx.send(soundscape::UpdateFn::from(update).into()).ok();
+        self.soundscape_tx
+            .send(soundscape::UpdateFn::from(update).into())
+            .ok();
 
         // Detection thread.
         self.detection.remove_sound(id);
@@ -586,7 +599,9 @@ pub fn render(model: &mut Model, buffer: &mut Buffer) {
     // `unmixed_sounds` buffer.
     for (sound_i, ordered_sound) in sounds_ordered.iter_mut().enumerate() {
         let sound_id = ordered_sound.id;
-        let sound = sounds.get_mut(&sound_id).expect("no sound for the given `Id`");
+        let sound = sounds
+            .get_mut(&sound_id)
+            .expect("no sound for the given `Id`");
 
         // Update the ordered sound.
         ordered_sound.channels = sound.channels;
@@ -605,10 +620,7 @@ pub fn render(model: &mut Model, buffer: &mut Buffer) {
         let msg = gui::AudioMonitorMessage::ActiveSound(sound_id, update);
         channels.gui_audio_monitor_msg_tx.push(msg);
 
-        let ActiveSound {
-            ref mut sound,
-            ..
-        } = *sound;
+        let ActiveSound { ref mut sound, .. } = *sound;
 
         // The number of samples to request from the sound for this buffer.
         let num_samples = buffer.len_frames() * sound.channels;
@@ -648,7 +660,9 @@ pub fn render(model: &mut Model, buffer: &mut Buffer) {
             if !cpu_saving_enabled {
                 let mut detection_buffer = channels.detection.pop_sound_buffer();
                 detection_buffer.extend(ordered_sound.unmixed_samples.iter().cloned());
-                channels.detection.update_sound(sound_id, detection_buffer, n_channels);
+                channels
+                    .detection
+                    .update_sound(sound_id, detection_buffer, n_channels);
             }
 
             // If we didn't write the expected number of samples, the sound has been exhausted.
@@ -692,32 +706,21 @@ pub fn render(model: &mut Model, buffer: &mut Buffer) {
                 let speaker_point = &active.speaker.point;
 
                 // Get the current gain by performing DBAP calc.
-                let channel_point_f = Point2 {
-                    x: channel_point.x.0,
-                    y: channel_point.y.0,
-                };
-                let speaker_point_f = Point2 {
-                    x: speaker_point.x.0,
-                    y: speaker_point.y.0,
-                };
+                let channel_point_f = Point2::new(channel_point.x, channel_point.y);
+                let speaker_point_f = Point2::new(speaker_point.x, speaker_point.y);
 
                 // Get the squared distance between the channel and speaker.
-                let distance_2 = dbap::blurred_distance_2(
-                    channel_point_f,
-                    speaker_point_f,
-                    DISTANCE_BLUR,
-                );
+                let distance_2 =
+                    dbap::blurred_distance_2(channel_point_f, speaker_point_f, DISTANCE_BLUR);
 
                 // If this speaker is not within proximity, skip it.
-                if proximity_limit_2 < Metres(distance_2) {
+                if proximity_limit_2 < distance_2 {
                     continue;
                 }
 
                 // Weight the speaker based on whether or not it is assigned.
-                let weight = speaker::dbap_weight(
-                    &sound.installations,
-                    &active.speaker.installations,
-                );
+                let weight =
+                    self::speaker::dbap_weight(&sound.installations, &active.speaker.installations);
 
                 // TODO: Possibly skip speakers with a weight of 0 (as below)?
                 // Uncertain how this will affect DBAP, but may drastically improve CPU.
@@ -746,7 +749,10 @@ pub fn render(model: &mut Model, buffer: &mut Buffer) {
 
                 // Create the `dbap::Speaker` so that we may determine the current gain. This
                 // is done following this loop.
-                let speaker = dbap::Speaker { distance: distance_2, weight };
+                let speaker = dbap::Speaker {
+                    distance: distance_2,
+                    weight,
+                };
                 dbap_speakers.push(speaker);
                 dbap_speaker_infos.push(dbap_speaker_info);
             }
@@ -827,17 +833,17 @@ pub fn render(model: &mut Model, buffer: &mut Buffer) {
     let (mut detection_buffer, mut output_info) = channels.detection.pop_output_buffer();
     detection_buffer.extend(buffer.iter().cloned());
     output_info.speakers.extend({
-        speakers
-            .iter()
-            .map(|(&id, speaker)| {
-                let info = detection::SpeakerInfo {
-                    channel: speaker.channel,
-                    installations: speaker.installations.clone(),
-                };
-                (id, info)
-            })
+        speakers.iter().map(|(&id, speaker)| {
+            let info = detection::SpeakerInfo {
+                channel: speaker.channel,
+                installations: speaker.installations.clone(),
+            };
+            (id, info)
+        })
     });
-    channels.detection.update_output(detection_buffer, buffer.channels(), output_info);
+    channels
+        .detection
+        .update_output(detection_buffer, buffer.channels(), output_info);
 
     // Remove all sounds that have been exhausted.
     for sound_id in exhausted_sounds.drain(..) {
@@ -856,19 +862,21 @@ pub fn render(model: &mut Model, buffer: &mut Buffer) {
 
     // Find the peak amplitude and send it via the monitor channel.
     let peak = buffer.iter().fold(0.0, |peak, &s| s.max(peak));
-    channels.gui_audio_monitor_msg_tx.push(gui::AudioMonitorMessage::Master { peak });
+    channels
+        .gui_audio_monitor_msg_tx
+        .push(gui::AudioMonitorMessage::Master { peak });
 
     // Step the frame count.
     frame_count.fetch_add(buffer.len_frames(), atomic::Ordering::Relaxed);
 }
 
 pub fn channel_point(
-    sound_point: Point2<Metres>,
+    sound_point: Point2,
     channel_index: usize,
     total_channels: usize,
     spread: Metres,
     radians: f32,
-) -> Point2<Metres> {
+) -> Point2 {
     assert!(channel_index < total_channels);
     if total_channels == 1 {
         sound_point
@@ -876,25 +884,22 @@ pub fn channel_point(
         let phase = channel_index as f32 / total_channels as f32;
         let channel_radians_offset = phase * std::f32::consts::PI * 2.0;
         let radians = (radians + channel_radians_offset) as f64;
-        let (rel_x, rel_y) = utils::rad_mag_to_x_y(radians, spread.0);
-        let x = sound_point.x + Metres(rel_x);
-        let y = sound_point.y + Metres(rel_y);
-        Point2 { x, y }
+        let (rel_x, rel_y) = utils::rad_mag_to_x_y(radians, spread);
+        let x: Metres = sound_point.x + (rel_x);
+        let y: Metres = sound_point.y + (rel_y);
+        Point2::new(x, y)
     }
 }
 
 /// Tests whether or not the given speaker position is within the `PROXIMITY_LIMIT` distance of the
 /// given `point` (normally a `Sound`'s channel position).
-pub fn speaker_is_in_proximity(point: &Point2<Metres>, speaker: &Point2<Metres>,
-                               proximity_limit_2: Metres) -> bool {
-    let point_f = Point2 {
-        x: point.x.0,
-        y: point.y.0,
-    };
-    let speaker_f = Point2 {
-        x: speaker.x.0,
-        y: speaker.y.0,
-    };
-    let distance_2 = Metres(point_f.distance2(speaker_f));
+pub fn speaker_is_in_proximity(
+    point: &Point2,
+    speaker: &Point2,
+    proximity_limit_2: Metres,
+) -> bool {
+    let point_f = Point2::new(point.x, point.y);
+    let speaker_f = Point2::new(speaker.x, speaker.y);
+    let distance_2 = point_f.distance(speaker_f);
     distance_2 < proximity_limit_2
 }

--- a/src/lib/audio/sound.rs
+++ b/src/lib/audio/sound.rs
@@ -1,13 +1,15 @@
-use audio::{input, output, source, Source, SAMPLE_RATE};
-use crossbeam::sync::SegQueue;
+use crate::audio::{input, output, source, Source, SAMPLE_RATE};
+use crate::installation;
+use crate::metres::Metres;
+use crossbeam::queue::SegQueue;
 use fxhash::FxHashSet;
-use installation;
-use metres::Metres;
-use nannou::geom::Point2;
+use serde::{Deserialize, Serialize};
 use std::ops;
-use std::sync::{Arc, Mutex};
 use std::sync::atomic::{self, AtomicBool};
+use std::sync::{Arc, Mutex};
 use time_calc::{Ms, Samples};
+
+type Point2 = nannou::glam::DVec2;
 
 /// `Sound`s can be thought of as a stack of three primary components:
 ///
@@ -51,7 +53,7 @@ pub struct Sound {
 #[derive(Copy, Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct Position {
     /// The location within the exhibition within metres.
-    pub point: Point2<Metres>,
+    pub point: Point2,
     /// The orientation of the sound.
     #[serde(default)]
     pub radians: f32,
@@ -67,9 +69,7 @@ pub struct Handle {
 #[derive(Debug)]
 pub enum SourceHandle {
     Wav,
-    Realtime {
-        is_capturing: Arc<AtomicBool>,
-    },
+    Realtime { is_capturing: Arc<AtomicBool> },
 }
 
 // State shared between multiple handles to a single sound.
@@ -115,7 +115,9 @@ impl Handle {
         if let SourceHandle::Realtime { ref is_capturing } = self.shared.source {
             is_capturing.store(false, atomic::Ordering::Relaxed);
         }
-        self.shared.is_playing.store(false, atomic::Ordering::Relaxed);
+        self.shared
+            .is_playing
+            .store(false, atomic::Ordering::Relaxed);
         result
     }
 
@@ -127,7 +129,9 @@ impl Handle {
         if let SourceHandle::Realtime { ref is_capturing } = self.shared.source {
             is_capturing.store(true, atomic::Ordering::Relaxed);
         }
-        self.shared.is_playing.store(true, atomic::Ordering::Relaxed);
+        self.shared
+            .is_playing
+            .store(true, atomic::Ordering::Relaxed);
         result
     }
 
@@ -154,51 +158,46 @@ pub fn spawn_from_source(
     input_stream: &input::Stream,
     output_stream: &output::Stream,
     latency: Ms,
-) -> Handle
-{
+) -> Handle {
     let installations = source.role.clone().into();
     match source.kind {
-        source::Kind::Wav(ref wav) => {
-            spawn_from_wav(
-                id,
-                source_id,
-                wav,
-                source.spread,
-                source.volume,
-                source.muted,
-                position,
-                source.channel_radians,
-                installations,
-                attack_duration_frames,
-                release_duration_frames,
-                continuous_preview,
-                max_duration_frames,
-                frame_count,
-                wav_reader,
-                output_stream,
-            )
-        },
+        source::Kind::Wav(ref wav) => spawn_from_wav(
+            id,
+            source_id,
+            wav,
+            source.spread,
+            source.volume,
+            source.muted,
+            position,
+            source.channel_radians,
+            installations,
+            attack_duration_frames,
+            release_duration_frames,
+            continuous_preview,
+            max_duration_frames,
+            frame_count,
+            wav_reader,
+            output_stream,
+        ),
 
-        source::Kind::Realtime(ref realtime) => {
-            spawn_from_realtime(
-                id,
-                source_id,
-                realtime,
-                source.spread,
-                source.volume,
-                source.muted,
-                position,
-                source.channel_radians,
-                installations,
-                attack_duration_frames,
-                release_duration_frames,
-                continuous_preview,
-                max_duration_frames,
-                input_stream,
-                output_stream,
-                latency,
-            )
-        },
+        source::Kind::Realtime(ref realtime) => spawn_from_realtime(
+            id,
+            source_id,
+            realtime,
+            source.spread,
+            source.volume,
+            source.muted,
+            position,
+            source.channel_radians,
+            installations,
+            attack_duration_frames,
+            release_duration_frames,
+            continuous_preview,
+            max_duration_frames,
+            input_stream,
+            output_stream,
+            latency,
+        ),
     }
 }
 
@@ -220,13 +219,22 @@ pub fn spawn_from_wav(
     frame_count: u64,
     wav_reader: &source::wav::reader::Handle,
     audio_output: &output::Stream,
-) -> Handle
-{
+) -> Handle {
     // The wave samples iterator.
-    let samples = wav_reader.play(id, &wav.path, frame_count, wav.should_loop || continuous_preview)
+    let samples = wav_reader
+        .play(
+            id,
+            &wav.path,
+            frame_count,
+            wav.should_loop || continuous_preview,
+        )
         .unwrap_or_else(|err| {
-            panic!("failed to send new wav \"{}\"to wav_reader thread: {:?}: {}",
-                   wav.path.display(), err, err);
+            panic!(
+                "failed to send new wav \"{}\"to wav_reader thread: {:?}: {}",
+                wav.path.display(),
+                err,
+                err
+            );
         });
 
     // The source signal.
@@ -262,9 +270,7 @@ pub fn spawn_from_wav(
     };
 
     // Create the handle to the sound.
-    let handle = Handle {
-        shared,
-    };
+    let handle = Handle { shared };
 
     // The output stream active sound.
     let output_active_sound = sound.into();
@@ -369,9 +375,7 @@ pub fn spawn_from_realtime(
     };
 
     // State shared between the handles to a realtime sound.
-    let source_handle = SourceHandle::Realtime {
-        is_capturing,
-    };
+    let source_handle = SourceHandle::Realtime { is_capturing };
 
     // State shared between the handles to the sound.
     let shared = Arc::new(Shared {
@@ -395,9 +399,7 @@ pub fn spawn_from_realtime(
     };
 
     // Create the handle to the sound.
-    let handle = Handle {
-        shared,
-    };
+    let handle = Handle { shared };
 
     // The output stream active sound.
     let output_active_sound = sound.into();
@@ -427,13 +429,19 @@ impl Sound {
     /// The location of the channel at the given index.
     ///
     /// Returns `None` if there is no channel for the given index.
-    pub fn channel_point(&self, index: usize) -> Option<Point2<Metres>> {
+    pub fn channel_point(&self, index: usize) -> Option<Point2> {
         if self.channels <= index {
             return None;
         }
         let point = self.position.point;
         let radians = self.position.radians + self.channel_radians;
-        Some(super::output::channel_point(point, index, self.channels, self.spread, radians))
+        Some(super::output::channel_point(
+            point,
+            index,
+            self.channels,
+            self.spread,
+            radians,
+        ))
     }
 
     /// Produce an iterator yielding the location of each channel around the sound.
@@ -469,7 +477,7 @@ impl From<source::Role> for Installations {
 }
 
 impl ops::Deref for Position {
-    type Target = Point2<Metres>;
+    type Target = Point2;
     fn deref(&self) -> &Self::Target {
         &self.point
     }
@@ -482,14 +490,12 @@ impl ops::DerefMut for Position {
 }
 
 impl<'a> Iterator for ChannelPoints<'a> {
-    type Item = Point2<Metres>;
+    type Item = Point2;
     fn next(&mut self) -> Option<Self::Item> {
-        self.sound
-            .channel_point(self.index)
-            .map(|point| {
-                self.index +=1 ;
-                point
-            })
+        self.sound.channel_point(self.index).map(|point| {
+            self.index += 1;
+            point
+        })
     }
 }
 
@@ -514,7 +520,9 @@ impl IdGenerator {
     }
 
     pub fn generate_next(&self) -> Id {
-        let mut next = self.next.lock()
+        let mut next = self
+            .next
+            .lock()
             .expect("failed to acquire mutex for generating new `sound::Id`");
         let id = *next;
         *next = Id(id.0.wrapping_add(1));

--- a/src/lib/audio/source/mod.rs
+++ b/src/lib/audio/source/mod.rs
@@ -1,12 +1,13 @@
+use crate::installation;
+use crate::metres::Metres;
+use crate::soundscape;
+use crate::utils::{self, Range};
 use fxhash::FxHashSet;
-use installation;
-use metres::Metres;
 use nannou::math::map_range;
 use nannou::rand::Rng;
-use soundscape;
+use serde::{Deserialize, Serialize};
 use std::ops;
 use time_calc::{Ms, Samples};
-use utils::{self, Range};
 
 pub use self::movement::Movement;
 pub use self::realtime::Realtime;
@@ -154,9 +155,12 @@ pub struct Soundscape {
 
 /// Items related to the movement of a source's associated sounds within a soundscape.
 pub mod movement {
-    use nannou::geom::{Point2, Vector2};
+    use crate::utils::Range;
+    use nannou::glam::DVec2 as Vector2;
+    use nannou::glam::DVec2 as Point2;
     use nannou::prelude::PI_F64;
-    use utils::Range;
+    use serde::Deserialize;
+    use serde::Serialize;
 
     /// The absolute maximum speed of an agent.
     pub const MAX_SPEED: f64 = 20.0;
@@ -192,7 +196,7 @@ pub mod movement {
     #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
     pub enum Movement {
         /// The position normalised to the constraints of the installation.
-        Fixed(Point2<f64>),
+        Fixed(Point2),
         Generative(Generative),
     }
 
@@ -234,7 +238,7 @@ pub mod movement {
         ///
         /// `0.0` means all points will be in the center.
         /// `1.0` means all points will extend to the bounds of the installation area.
-        pub normalised_dimensions: Vector2<f64>,
+        pub normalised_dimensions: Vector2,
         /// Some rotation that is applied to the Ngon's points around the centre.
         #[serde(default = "super::default::radians_offset")]
         pub radians_offset: Range<f64>,
@@ -352,7 +356,12 @@ where
     let range_duration = range.max - range.min;
     let skew = playback_duration_skew(range_duration);
     let skewed_normalised_value = rng.gen::<f64>().powf(skew as f64);
-    Ms(utils::unskew_and_unnormalise(skewed_normalised_value, range.min.0, range.max.0, skew))
+    Ms(utils::unskew_and_unnormalise(
+        skewed_normalised_value,
+        range.min.0,
+        range.max.0,
+        skew,
+    ))
 }
 
 impl Source {
@@ -368,7 +377,10 @@ impl Attack {
     /// Construct an `Attack` from its duration in frames.
     pub fn from_duration_frames(duration_frames: Samples) -> Self {
         let current_frame = Samples(0);
-        Attack { duration_frames, current_frame }
+        Attack {
+            duration_frames,
+            current_frame,
+        }
     }
 }
 
@@ -376,7 +388,10 @@ impl Release {
     /// Construct a `Release` from its duration in frames.
     pub fn from_duration_frames(duration_frames: Samples) -> Self {
         let frame_countdown = duration_frames;
-        Release { duration_frames, frame_countdown }
+        Release {
+            duration_frames,
+            frame_countdown,
+        }
     }
 }
 
@@ -384,7 +399,10 @@ impl Duration {
     /// Construct a `Duration` from its frames.
     pub fn from_frames(duration_frames: Samples) -> Self {
         let current_frame = Samples(0);
-        Duration { duration_frames, current_frame }
+        Duration {
+            duration_frames,
+            current_frame,
+        }
     }
 }
 
@@ -408,7 +426,9 @@ impl SignalKind {
     /// Borrow the inner iterator yielding samples.
     pub fn samples(&mut self) -> &mut dyn Iterator<Item = f32> {
         match *self {
-            SignalKind::Wav { ref mut samples, .. } => samples as _,
+            SignalKind::Wav {
+                ref mut samples, ..
+            } => samples as _,
             SignalKind::Realtime { ref mut samples } => samples as _,
         }
     }
@@ -420,7 +440,12 @@ impl Signal {
         let attack = Attack::from_duration_frames(attack_frames);
         let release = Release::from_duration_frames(release_frames);
         let duration = None;
-        Signal { kind, attack, release, duration }
+        Signal {
+            kind,
+            attack,
+            release,
+            duration,
+        }
     }
 
     /// Specify the duration of the signal in frames in the `Signal`.
@@ -465,7 +490,7 @@ impl Signal {
                     release.frame_countdown = ::std::cmp::min(release.frame_countdown, frames);
                 }
                 frames_until_release
-            },
+            }
             None => Samples(::std::i64::MAX),
         };
 
@@ -606,28 +631,41 @@ pub mod skew {
 }
 
 pub mod default {
-    use metres::Metres;
-    use nannou::geom::{Point2, Vector2};
     use super::{movement, Movement};
+    use crate::metres::Metres;
+    use crate::utils::{Range, HR_MS};
+    use nannou::glam::DVec2 as Vector2;
+    use nannou::glam::{const_dvec2, DVec2 as Point2};
     use time_calc::Ms;
-    use utils::{HR_MS, Range};
 
-    pub const SPREAD: Metres = Metres(2.5);
+    pub const SPREAD: Metres = 2.5;
     // Rotate the channel radians 90deg so that stereo channels are to the side by default.
     pub const CHANNEL_RADIANS: f32 = ::std::f32::consts::PI * 0.5;
     pub const VOLUME: f32 = 0.6;
-    pub const OCCURRENCE_RATE: Range<Ms> = Range { min: Ms(500.0), max: Ms(HR_MS as _) };
+    pub const OCCURRENCE_RATE: Range<Ms> = Range {
+        min: Ms(500.0),
+        max: Ms(HR_MS as _),
+    };
     pub const SIMULTANEOUS_SOUNDS: Range<usize> = Range { min: 0, max: 1 };
     // Assume that the user wants to play back the sound endlessly at first.
     pub const PLAYBACK_DURATION: Range<Ms> = Range {
         min: super::MAX_PLAYBACK_DURATION,
         max: super::MAX_PLAYBACK_DURATION,
     };
-    pub const ATTACK_DURATION: Range<Ms> = Range { min: Ms(0.0), max: Ms(0.0) };
-    pub const RELEASE_DURATION: Range<Ms> = Range { min: Ms(0.0), max: Ms(0.0) };
-    pub const FIXED: Point2<f64> = Point2 { x: 0.5, y: 0.5 };
+    pub const ATTACK_DURATION: Range<Ms> = Range {
+        min: Ms(0.0),
+        max: Ms(0.0),
+    };
+    pub const RELEASE_DURATION: Range<Ms> = Range {
+        min: Ms(0.0),
+        max: Ms(0.0),
+    };
+    pub const FIXED: Point2 = const_dvec2!([0.5, 0.5]);
     pub const MAX_SPEED: Range<f64> = Range { min: 1.0, max: 5.0 };
-    pub const MAX_FORCE: Range<f64> = Range { min: 0.04, max: 0.06 };
+    pub const MAX_FORCE: Range<f64> = Range {
+        min: 0.04,
+        max: 0.06,
+    };
     pub const MAX_ROTATION: Range<f64> = Range {
         min: super::movement::MAX_ROTATION,
         max: super::movement::MAX_ROTATION,
@@ -643,11 +681,8 @@ pub mod default {
     pub const NTH: Range<usize> = Range { min: 1, max: 3 };
     pub const NORMALISED_WIDTH: f64 = 1.0;
     pub const NORMALISED_HEIGHT: f64 = 1.0;
-    pub const NORMALISED_DIMENSIONS: Vector2<f64> = Vector2 {
-        x: NORMALISED_WIDTH,
-        y: NORMALISED_HEIGHT,
-    };
-    pub const RADIANS_OFFSET: Range<f64> = Range {
+    pub const NORMALISED_DIMENSIONS: Vector2 = const_dvec2!([NORMALISED_WIDTH, NORMALISED_HEIGHT]);
+    pub const RADIANS_OFFSET: Range<f64> = Range::<f64> {
         min: ::std::f64::consts::PI * 0.5,
         max: ::std::f64::consts::PI * 0.5,
     };

--- a/src/lib/audio/source/wav/mod.rs
+++ b/src/lib/audio/source/wav/mod.rs
@@ -1,5 +1,6 @@
-use audio;
+use crate::audio;
 use hound;
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use time_calc::{Ms, SampleHz, Samples};
 
@@ -52,8 +53,12 @@ impl Wav {
         let spec = reader.spec();
         let channels = spec.channels as usize;
         let sample_hz = spec.sample_rate as _;
-        assert_eq!(sample_hz, audio::SAMPLE_RATE,
-                   "WAV files must have a sample rate of {}", audio::SAMPLE_RATE);
+        assert_eq!(
+            sample_hz,
+            audio::SAMPLE_RATE,
+            "WAV files must have a sample rate of {}",
+            audio::SAMPLE_RATE
+        );
         let duration = Samples(reader.duration() as _);
         let playback = default_playback();
         let should_loop = default_should_loop();

--- a/src/lib/audio/source/wav/reader.rs
+++ b/src/lib/audio/source/wav/reader.rs
@@ -612,21 +612,22 @@ fn run(tx: Tx, rx: Rx) {
 /// the parent thread in their processed form.
 fn run_child(child_msg_queue: Arc<ChildMessageQueue>, parent_tx: Tx) {
     loop {
-        let msg = child_msg_queue.pop().unwrap(); // TODO (ando: 2022-06-09): check if unwrap logic is correct
-        match msg {
-            // Play the given sound and return the resulting `Sound` to the parent.
-            ChildMessage::Play(sound_id, play) => {
-                let sound = play_sound(play);
-                let msg = Message::PlayComplete(sound_id, sound);
-                parent_tx.push(msg);
-            }
+        if let Some(msg) = child_msg_queue.pop() {
+            match msg {
+                // Play the given sound and return the resulting `Sound` to the parent.
+                ChildMessage::Play(sound_id, play) => {
+                    let sound = play_sound(play);
+                    let msg = Message::PlayComplete(sound_id, sound);
+                    parent_tx.push(msg);
+                }
 
-            // Process the next buffer and return the resulting `Sound` to the parent thread.
-            ChildMessage::NextBuffer(sound_id, mut sound, buffer) => {
-                next_buffer(sound_id, &mut sound, buffer, &parent_tx)
-                    .expect("failed to process next buffer");
-                let msg = Message::NextBufferComplete(sound_id, sound);
-                parent_tx.push(msg);
+                // Process the next buffer and return the resulting `Sound` to the parent thread.
+                ChildMessage::NextBuffer(sound_id, mut sound, buffer) => {
+                    next_buffer(sound_id, &mut sound, buffer, &parent_tx)
+                        .expect("failed to process next buffer");
+                    let msg = Message::NextBufferComplete(sound_id, sound);
+                    parent_tx.push(msg);
+                }
             }
         }
     }

--- a/src/lib/audio/source/wav/reader.rs
+++ b/src/lib/audio/source/wav/reader.rs
@@ -1,22 +1,22 @@
 //! A thread dedicated to reading sounds from WAV files and feeding their samples to sounds on the
 //! audio thread.
 
-use audio::{self, sound};
-use crossbeam::sync::{MsQueue, SegQueue};
+use crate::audio::{self, sound};
+use crossbeam::queue::SegQueue;
 use fxhash::FxHashMap;
 use hound::{self, SampleFormat};
 use num_cpus;
 use std::cell::RefCell;
 use std::collections::VecDeque;
-use std::io::BufReader;
 use std::fs::File;
+use std::io::BufReader;
 use std::mem;
 use std::ops;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use time_calc::Samples;
 use threadpool::ThreadPool;
+use time_calc::Samples;
 
 /// The number of sample buffers that the `reader` thread prepares ahead of time for a single
 /// sound.
@@ -26,10 +26,10 @@ const NUM_BUFFERS: usize = 4;
 pub type WavReader = hound::WavReader<BufReader<File>>;
 
 /// Sends messages to the `wav::reader` thread.
-pub type Tx = Arc<MsQueue<Message>>;
+pub type Tx = Arc<SegQueue<Message>>;
 
 /// Receives `Message`s for the `wav::reader` thread.
-pub type Rx = Arc<MsQueue<Message>>;
+pub type Rx = Arc<SegQueue<Message>>;
 
 /// For sending buffers to a sound's associated `ThreadedSamplesStream`.
 pub type BufferTx = Arc<SegQueue<Buffer>>;
@@ -38,7 +38,7 @@ pub type BufferTx = Arc<SegQueue<Buffer>>;
 pub type BufferRx = Arc<SegQueue<Buffer>>;
 
 /// The mpmc queue used for distributing `Play` messages across the child threads.
-type ChildMessageQueue = MsQueue<ChildMessage>;
+type ChildMessageQueue = SegQueue<ChildMessage>;
 
 /// A unique identifier associated with a child thread.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -180,15 +180,19 @@ impl Handle {
         wav_path: &Path,
         start_frame: u64,
         looped: bool,
-    ) -> Result<SamplesStream, hound::Error>
-    {
+    ) -> Result<SamplesStream, hound::Error> {
         let reader = WavReader::open(wav_path)?;
         let wav_len_samples = reader.len() as _;
         let buffer_queue = Arc::new(SegQueue::new());
         let buffer_tx = buffer_queue.clone();
         let buffer_rx = buffer_queue;
         let spec = reader.spec();
-        let play = Play { reader, buffer_tx, start_frame, looped };
+        let play = Play {
+            reader,
+            buffer_tx,
+            start_frame,
+            looped,
+        };
         let samples_stream = SamplesStream::new(buffer_rx, spec, wav_len_samples, looped);
         let msg = Message::Play(sound_id, play);
         self.tx.push(msg);
@@ -262,7 +266,7 @@ impl SamplesStream {
             }
 
             let mut buffer_mut = self.buffer.borrow_mut();
-            *buffer_mut = match self.buffer_rx.try_pop() {
+            *buffer_mut = match self.buffer_rx.pop() {
                 None => return Some(Samples(self.wav_len_samples as _)),
                 Some(buffer) => Some(buffer),
             };
@@ -295,14 +299,14 @@ impl SamplesStream {
             mem::drop(buffer_mut.take());
 
             // Receive the next buffer.
-            *buffer_mut = match buffer_rx.try_pop() {
+            *buffer_mut = match buffer_rx.pop() {
                 // If there are no more buffers, there must be no more samples so we're done.
                 None => return None,
                 // Otherwise reset
                 Some(buffer) => {
                     *buffer_index = 0;
                     Some(buffer)
-                },
+                }
             };
         }
     }
@@ -319,16 +323,18 @@ impl Model {
     /// Initialise the `Model`.
     fn new(tx: Tx) -> Self {
         let sounds = FxHashMap::default();
-        Model {
-            sounds,
-            tx,
-        }
+        Model { sounds, tx }
     }
 }
 
 /// Process the given `Play` command and return the resulting `Sound`.
 fn play_sound(play: Play) -> Sound {
-    let Play { mut reader, buffer_tx, start_frame, looped } = play;
+    let Play {
+        mut reader,
+        buffer_tx,
+        start_frame,
+        looped,
+    } = play;
 
     // Seek to the given `start_frame` within the file.
     //
@@ -339,7 +345,8 @@ fn play_sound(play: Play) -> Sound {
     // wrapped around to the beginning.
     let duration_frames = reader.duration() as u64;
     let frames = start_frame % duration_frames;
-    reader.seek(frames as u32)
+    reader
+        .seek(frames as u32)
         .expect("failed to seek to start frame in wav source");
 
     // Prepare the buffers for the sound.
@@ -348,11 +355,13 @@ fn play_sound(play: Play) -> Sound {
         .map(|_| {
             let mut samples = vec![];
             let start_sample = wav_len_samples - super::samples::remaining(&mut reader);
-            fill_buffer(&mut reader, &mut samples, looped)
-                .expect("failed to fill buffer");
+            fill_buffer(&mut reader, &mut samples, looped).expect("failed to fill buffer");
             let end_sample = wav_len_samples - super::samples::remaining(&mut reader);
             let samples_range = start_sample..end_sample;
-            PreparedBuffer { samples, samples_range }
+            PreparedBuffer {
+                samples,
+                samples_range,
+            }
         })
         .collect();
 
@@ -387,10 +396,19 @@ fn next_buffer(
     let wav_len_samples = reader.len() as usize;
 
     // First, send the next queued buffer over the channel.
-    if let Some(PreparedBuffer { samples, samples_range }) = prepared_buffers.pop_front() {
+    if let Some(PreparedBuffer {
+        samples,
+        samples_range,
+    }) = prepared_buffers.pop_front()
+    {
         let reader_tx = parent_tx.clone();
         let info = BufferInfo { samples_range };
-        let buffer = Buffer { samples, sound_id, reader_tx, info };
+        let buffer = Buffer {
+            samples,
+            sound_id,
+            reader_tx,
+            info,
+        };
         // The output thread may have exited before us so ignore closed channel error.
         buffer_tx.push(buffer);
     }
@@ -400,7 +418,10 @@ fn next_buffer(
     fill_buffer(reader, &mut samples, looped)?;
     let end = wav_len_samples - super::samples::remaining(reader);
     let samples_range = start..end;
-    let prepared_buffer = PreparedBuffer { samples, samples_range };
+    let prepared_buffer = PreparedBuffer {
+        samples,
+        samples_range,
+    };
     prepared_buffers.push_back(prepared_buffer);
 
     Ok(())
@@ -438,14 +459,13 @@ fn fill_buffer(
 fn read_next_sample_cycled(
     reader: &mut WavReader,
     spec: &hound::WavSpec,
-) -> Result<f32, hound::Error>
-{
+) -> Result<f32, hound::Error> {
     loop {
         match read_next_sample(reader, spec)? {
             Some(sample) => return Ok(sample),
             None => {
                 reader.seek(0)?;
-            },
+            }
         }
     }
 }
@@ -456,8 +476,7 @@ fn read_next_sample_cycled(
 fn read_next_sample(
     reader: &mut WavReader,
     spec: &hound::WavSpec,
-) -> Result<Option<f32>, hound::Error>
-{
+) -> Result<Option<f32>, hound::Error> {
     // A macro to simplify requesting and returning the next sample.
     macro_rules! next_sample {
         ($T:ty) => {{
@@ -478,7 +497,7 @@ fn read_next_sample(
                     "Unsupported bit depth {} - currently only 8, 16 and 32 are supported",
                     spec.bits_per_sample
                 );
-            },
+            }
         }
         return Ok(None);
     }
@@ -487,7 +506,7 @@ fn read_next_sample(
 /// Runs the wav reader thread and returns a handle to it that may be used to play or seek sounds
 /// via their unique `Id`.
 pub fn spawn() -> Handle {
-    let queue = Arc::new(MsQueue::new());
+    let queue = Arc::new(SegQueue::new());
     let tx = queue.clone();
     let rx = queue;
     let tx2 = tx.clone();
@@ -530,14 +549,14 @@ fn run(tx: Tx, rx: Rx) {
     }
 
     loop {
-        let msg = rx.pop();
+        let msg = rx.pop().unwrap_or(Message::Exit);
         match msg {
             // Enqueue a play message for one of the child threads to process.
             Message::Play(sound_id, play) => {
                 model.sounds.insert(sound_id, SoundState::Processing);
                 let child_msg = ChildMessage::Play(sound_id, play);
                 child_message_queue.push(child_msg);
-            },
+            }
 
             // Insert the `Play`ed sound into the map so that we may track its state.
             Message::PlayComplete(sound_id, sound) => {
@@ -549,7 +568,7 @@ fn run(tx: Tx, rx: Rx) {
                     let msg = Message::NextBuffer(sound_id, vec![]);
                     model.tx.push(msg);
                 }
-            },
+            }
 
             // Queue the sound ready for one of the children to process the next buffer.
             Message::NextBuffer(sound_id, buffer) => {
@@ -560,31 +579,31 @@ fn run(tx: Tx, rx: Rx) {
                     SoundState::Processing => {
                         let msg = Message::NextBuffer(sound_id, buffer);
                         model.tx.push(msg);
-                    },
+                    }
                     // If the sound was waiting, send it to a child thread for processing.
                     SoundState::Waiting(sound) => {
                         let child_msg = ChildMessage::NextBuffer(sound_id, sound, buffer);
                         child_message_queue.push(child_msg);
-                    },
+                    }
                 }
-            },
+            }
 
             // Insert the sound back into the map ready for processing.
             Message::NextBufferComplete(sound_id, sound) => {
                 let state = get_mut_sound_or_continue!(sound_id);
                 *state = SoundState::Waiting(sound);
-            },
+            }
 
             // End the given sound by removing it from the map, dropping the reader and in turn
             // closing the underlying WAV file handle.
             Message::End(sound_id) => {
                 mem::drop(model.sounds.remove(&sound_id));
-            },
+            }
 
             // Break from waiting on messages as the program has exited.
             Message::Exit => {
                 break;
-            },
+            }
         }
     }
 }
@@ -593,14 +612,14 @@ fn run(tx: Tx, rx: Rx) {
 /// the parent thread in their processed form.
 fn run_child(child_msg_queue: Arc<ChildMessageQueue>, parent_tx: Tx) {
     loop {
-        let msg = child_msg_queue.pop();
+        let msg = child_msg_queue.pop().unwrap(); // TODO (ando: 2022-06-09): check if unwrap logic is correct
         match msg {
             // Play the given sound and return the resulting `Sound` to the parent.
             ChildMessage::Play(sound_id, play) => {
                 let sound = play_sound(play);
                 let msg = Message::PlayComplete(sound_id, sound);
                 parent_tx.push(msg);
-            },
+            }
 
             // Process the next buffer and return the resulting `Sound` to the parent thread.
             ChildMessage::NextBuffer(sound_id, mut sound, buffer) => {
@@ -608,7 +627,7 @@ fn run_child(child_msg_queue: Arc<ChildMessageQueue>, parent_tx: Tx) {
                     .expect("failed to process next buffer");
                 let msg = Message::NextBufferComplete(sound_id, sound);
                 parent_tx.push(msg);
-            },
+            }
         }
     }
 }

--- a/src/lib/audio/source/wav/samples.rs
+++ b/src/lib/audio/source/wav/samples.rs
@@ -1,18 +1,18 @@
 use hound;
-use nannou_audio::sample::{FromSample, Sample};
+use nannou_audio::dasp_sample::{FromSample, Sample};
 use std::io;
 
 /// Retrieve the next sample from the given wav reader samples iterator and yield it in the sample
 /// format type `S`.
-pub fn next<'a, R, H, S>(samples: &mut hound::WavSamples<'a, R, H>) -> Option<Result<S, hound::Error>>
+pub fn next<'a, R, H, S>(
+    samples: &mut hound::WavSamples<'a, R, H>,
+) -> Option<Result<S, hound::Error>>
 where
     H: hound::Sample + Sample,
     S: Sample + FromSample<H>,
     hound::WavSamples<'a, R, H>: Iterator<Item = Result<H, hound::Error>>,
 {
-    samples
-        .next()
-        .map(|r| r.map(Sample::to_sample))
+    samples.next().map(|r| r.map(Sample::to_sample))
 }
 
 /// The number of remaining samples in the reader from its current position.

--- a/src/lib/audio/speaker.rs
+++ b/src/lib/audio/speaker.rs
@@ -1,8 +1,9 @@
-use audio;
+use crate::audio;
+use crate::installation;
 use fxhash::FxHashSet;
-use installation;
-use metres::Metres;
-use nannou::geom::Point2;
+use nannou::glam::DVec2 as Point2;
+use serde::Deserialize;
+use serde::Serialize;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub struct Id(pub u64);
@@ -13,7 +14,7 @@ pub struct Id(pub u64);
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Speaker {
     // The location of the speaker within the space.
-    pub point: Point2<Metres>,
+    pub point: Point2,
     // The channel on which the output is rendered.
     pub channel: usize,
     // Installations assigned to this speaker.
@@ -25,8 +26,7 @@ pub struct Speaker {
 pub fn dbap_weight(
     sound_installations: &audio::sound::Installations,
     speaker_installations: &FxHashSet<installation::Id>,
-) -> f64
-{
+) -> f64 {
     match *sound_installations {
         audio::sound::Installations::All => 1.0,
         audio::sound::Installations::Set(ref set) => {
@@ -34,6 +34,6 @@ pub fn dbap_weight(
                 Some(_) => 1.0,
                 None => 0.0,
             }
-        },
+        }
     }
 }

--- a/src/lib/camera.rs
+++ b/src/lib/camera.rs
@@ -1,9 +1,9 @@
-use metres::Metres;
-use nannou::geom::Point2;
-use nannou::ui::Scalar;
+use crate::metres::Metres;
+use serde::{Deserialize, Serialize};
+type Scalar = f64;
 
 /// A 2D camera location in exhibition space.
-pub type Point = Point2<Metres>;
+pub type Point = nannou::glam::DVec2;
 
 /// Items related to the camera that provides a view of the floorplan.
 #[derive(Debug, Serialize, Deserialize)]
@@ -33,13 +33,13 @@ pub struct Camera {
 
 impl Camera {
     /// Convert from metres to the GUI scalar value.
-    pub fn metres_to_scalar(&self, Metres(metres): Metres) -> Scalar {
+    pub fn metres_to_scalar(&self, metres: Metres) -> Scalar {
         self.zoom * metres * self.floorplan_pixels_per_metre
     }
 
     /// Convert from the GUI scalar value to metres.
     pub fn scalar_to_metres(&self, scalar: Scalar) -> Metres {
-        Metres((scalar / self.zoom) / self.floorplan_pixels_per_metre)
+        ((scalar / self.zoom) / self.floorplan_pixels_per_metre) as Metres
     }
 }
 
@@ -48,12 +48,16 @@ impl Default for Camera {
         let position = default_position();
         let zoom = default_zoom();
         let floorplan_pixels_per_metre = default_floorplan_pixels_per_metre();
-        Camera { position, zoom, floorplan_pixels_per_metre }
+        Camera {
+            position,
+            zoom,
+            floorplan_pixels_per_metre,
+        }
     }
 }
 
 fn default_position() -> Point {
-    [Metres(0.0), Metres(0.0)].into()
+    [(0.0), (0.0)].into()
 }
 
 fn default_zoom() -> f64 {

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -1,4 +1,6 @@
-use project;
+use serde::{Deserialize, Serialize};
+
+use crate::project;
 use std::ops::Deref;
 
 /// Various configuration parameters for a single project.
@@ -53,7 +55,7 @@ impl Deref for Config {
 }
 
 mod default {
-    use project;
+    use crate::project;
     use slug::slugify;
     pub fn project_slug() -> String {
         slugify(project::default_project_name())

--- a/src/lib/gui/control_log.rs
+++ b/src/lib/gui/control_log.rs
@@ -1,12 +1,10 @@
-use gui::{collapsible_area, info_text, Gui};
-use nannou::ui::prelude::*;
-use project::Project;
+use crate::gui::{collapsible_area, info_text, Gui};
+use crate::project::Project;
+use nannou_conrod as ui;
+use nannou_conrod::prelude::*;
+use ui::{color, widget};
 
-pub fn set(
-    last_area_id: widget::Id,
-    gui: &mut Gui,
-    project: &Project,
-) -> widget::Id {
+pub fn set(last_area_id: widget::Id, gui: &mut Gui, project: &Project) -> widget::Id {
     let is_open = gui.state.is_open.control_log;
     let log_canvas_h = 200.0;
     let (area, event) = collapsible_area(is_open, "Control Log", gui.ids.side_menu)

--- a/src/lib/gui/monitor.rs
+++ b/src/lib/gui/monitor.rs
@@ -6,15 +6,15 @@
 //! not require performing some kind of I/O depending on the platform, in turn taking an
 //! unpredictable amount of time.
 
-use crossbeam::sync::{MsQueue, SegQueue};
-use gui;
+use crate::gui;
+use crossbeam::queue::SegQueue;
 use nannou;
 use std::io;
-use std::sync::Arc;
 use std::sync::atomic::{self, AtomicBool};
+use std::sync::Arc;
 use std::thread;
 
-pub type Sender = Arc<MsQueue<gui::AudioMonitorMessage>>;
+pub type Sender = Arc<SegQueue<gui::AudioMonitorMessage>>;
 pub type Receiver = Arc<SegQueue<gui::AudioMonitorMessage>>;
 pub type Spawned = (Monitor, Sender, Receiver);
 
@@ -40,7 +40,7 @@ impl Monitor {
 
 /// Spawn the intermediary monitoring thread and return the communication channels.
 pub fn spawn(app_proxy: nannou::app::Proxy) -> io::Result<Spawned> {
-    let audio_queue = Arc::new(MsQueue::new());
+    let audio_queue = Arc::new(SegQueue::new());
     let audio_tx = audio_queue.clone();
     let audio_rx = audio_queue;
 
@@ -59,7 +59,7 @@ pub fn spawn(app_proxy: nannou::app::Proxy) -> io::Result<Spawned> {
             // waking up.
             // Attempt to forward every message and wakeup the GUI when successful.
             'run: while !is_closed_2.load(atomic::Ordering::Relaxed) {
-                let msg = audio_rx.pop();
+                let msg = audio_rx.pop().unwrap();
                 gui_tx.push(msg);
                 // Proxy is currently buggy on linux so we only enable this for macos.
                 if cfg!(target_os = "macos") {

--- a/src/lib/gui/monitor.rs
+++ b/src/lib/gui/monitor.rs
@@ -59,8 +59,9 @@ pub fn spawn(app_proxy: nannou::app::Proxy) -> io::Result<Spawned> {
             // waking up.
             // Attempt to forward every message and wakeup the GUI when successful.
             'run: while !is_closed_2.load(atomic::Ordering::Relaxed) {
-                let msg = audio_rx.pop().unwrap();
-                gui_tx.push(msg);
+                if let Some(msg) = audio_rx.pop() {
+                    gui_tx.push(msg);
+                }
                 // Proxy is currently buggy on linux so we only enable this for macos.
                 if cfg!(target_os = "macos") {
                     if app_proxy.wakeup().is_err() {

--- a/src/lib/gui/osc_in_log.rs
+++ b/src/lib/gui/osc_in_log.rs
@@ -1,12 +1,10 @@
-use gui::{collapsible_area, info_text, Gui};
-use nannou::ui::prelude::*;
-use project::Project;
+use crate::gui::{collapsible_area, info_text, Gui};
+use crate::project::Project;
+use conrod_core as ui;
+use nannou_conrod::prelude::*;
+use ui::{color, widget};
 
-pub fn set(
-    last_area_id: widget::Id,
-    gui: &mut Gui,
-    project: &Project,
-) -> widget::Id {
+pub fn set(last_area_id: widget::Id, gui: &mut Gui, project: &Project) -> widget::Id {
     let is_open = gui.state.is_open.osc_in_log;
     let log_canvas_h = 200.0;
     let (area, event) = collapsible_area(is_open, "OSC Input Log", gui.ids.side_menu)

--- a/src/lib/gui/osc_out_log.rs
+++ b/src/lib/gui/osc_out_log.rs
@@ -1,10 +1,9 @@
-use gui::{collapsible_area, info_text, Gui};
-use nannou::ui::prelude::*;
+use crate::gui::{collapsible_area, info_text, Gui};
+use conrod_core as ui;
+use nannou_conrod::prelude::*;
+use ui::{color, widget};
 
-pub fn set(
-    last_area_id: widget::Id,
-    gui: &mut Gui,
-) -> widget::Id {
+pub fn set(last_area_id: widget::Id, gui: &mut Gui) -> widget::Id {
     let is_open = gui.state.is_open.osc_out_log;
     let log_canvas_h = 200.0;
     let (area, event) = collapsible_area(is_open, "OSC Output Log", gui.ids.side_menu)

--- a/src/lib/gui/soundscape_editor.rs
+++ b/src/lib/gui/soundscape_editor.rs
@@ -3,14 +3,15 @@
 //! - Play/Pause toggle for the soundscape.
 //! - Groups panel for creating/removing soundscape source groups.
 
-use gui::{collapsible_area, hz_label, Gui, ProjectState, State};
-use gui::{ITEM_HEIGHT, SMALL_FONT_SIZE};
-use project::{self, Project};
-use nannou::ui;
-use nannou::ui::prelude::*;
-use soundscape;
+use crate::gui::{collapsible_area, hz_label, Gui, ProjectState, State};
+use crate::gui::{ITEM_HEIGHT, SMALL_FONT_SIZE};
+use crate::project::{self, Project};
+use crate::soundscape;
+use crate::utils;
+use nannou_conrod as ui;
+use nannou_conrod::prelude::*;
 use time_calc::Ms;
-use utils;
+use ui::{color, position, widget, Scalar};
 
 /// GUI state related to the soundscape editor area.
 #[derive(Default)]
@@ -36,8 +37,7 @@ pub fn set(
         ref ids,
         channels,
         state: &mut State {
-            ref mut is_open,
-            ..
+            ref mut is_open, ..
         },
         ..
     } = gui;
@@ -65,16 +65,30 @@ pub fn set(
     const GROUP_CANVAS_H: Scalar = PAD + TITLE_H + PAD + PLUS_GROUP_H + GROUP_LIST_MAX_H + PAD;
     const SLIDER_H: Scalar = ITEM_HEIGHT;
     const SELECTED_CANVAS_H: Scalar = PAD
-        + TITLE_H + PAD * 2.0 + TEXT_BOX_H + PAD
-        + TITLE_H + PAD * 2.0 + SLIDER_H + PAD
-        + TITLE_H + PAD + SLIDER_H + PAD;
-    let soundscape_editor_canvas_h = PAD + IS_PLAYING_H + PAD + GROUP_CANVAS_H + PAD + SELECTED_CANVAS_H + PAD;
+        + TITLE_H
+        + PAD * 2.0
+        + TEXT_BOX_H
+        + PAD
+        + TITLE_H
+        + PAD * 2.0
+        + SLIDER_H
+        + PAD
+        + TITLE_H
+        + PAD
+        + SLIDER_H
+        + PAD;
+    let soundscape_editor_canvas_h =
+        PAD + IS_PLAYING_H + PAD + GROUP_CANVAS_H + PAD + SELECTED_CANVAS_H + PAD;
 
     // The collapsible area.
-    let (area, event) = collapsible_area(is_open.soundscape_editor, "Soundscape Editor", ids.side_menu)
-        .align_middle_x_of(ids.side_menu)
-        .down_from(last_area_id, 0.0)
-        .set(ids.soundscape_editor, ui);
+    let (area, event) = collapsible_area(
+        is_open.soundscape_editor,
+        "Soundscape Editor",
+        ids.side_menu,
+    )
+    .align_middle_x_of(ids.side_menu)
+    .down_from(last_area_id, 0.0)
+    .set(ids.soundscape_editor, ui);
     if let Some(event) = event {
         is_open.soundscape_editor = event.is_open();
     }
@@ -86,9 +100,7 @@ pub fn set(
     };
 
     // The canvas on which the soundscape editor will be placed.
-    let canvas = widget::Canvas::new()
-        .pad(PAD)
-        .h(soundscape_editor_canvas_h);
+    let canvas = widget::Canvas::new().pad(PAD).h(soundscape_editor_canvas_h);
     area.set(canvas, ui);
 
     // The toggle for whether or not the soundscape should be playing back.
@@ -227,12 +239,14 @@ pub fn set(
 
                 // If the button or any of its children are capturing the mouse, display
                 // the `remove` button.
-                let show_remove_button = ui.global_input()
+                let show_remove_button = ui
+                    .global_input()
                     .current
                     .widget_capturing_mouse
                     .map(|id| {
                         id == item.widget_id
-                            || ui.widget_graph()
+                            || ui
+                                .widget_graph()
                                 .does_recursive_depth_edge_exist(item.widget_id, id)
                     })
                     .unwrap_or(false);
@@ -254,13 +268,16 @@ pub fn set(
                 {
                     maybe_remove_index = Some(item.i);
                 }
-            },
+            }
 
             // Update the selected source.
             Event::Selection(idx) => {
                 soundscape_editor.selected = {
                     let (id, ref name) = groups_vec[idx];
-                    Some(Selected { id, name: name.clone() })
+                    Some(Selected {
+                        id,
+                        name: name.clone(),
+                    })
                 };
             }
 
@@ -300,8 +317,7 @@ pub fn set(
 
     // Only continue if there is some selected group.
     let SoundscapeEditor {
-        ref mut selected,
-        ..
+        ref mut selected, ..
     } = *soundscape_editor;
 
     let selected = match selected.as_mut() {
@@ -341,13 +357,13 @@ pub fn set(
             // When typing generally, only update the temp selected name.
             Event::Update(new_name) => {
                 selected.name = new_name;
-            },
+            }
             // Only when enter is pressed do we update the actual name.
             Event::Enter => {
                 if let Some(group) = soundscape_groups.get_mut(&selected.id) {
                     group.name = selected.name.clone();
                 }
-            },
+            }
         }
     }
 
@@ -399,7 +415,7 @@ pub fn set(
                 widget::range_slider::Edge::Start => {
                     let ms = utils::hz_to_ms_interval(hz);
                     group.occurrence_rate.max = ms;
-                },
+                }
                 widget::range_slider::Edge::End => {
                     let ms = utils::hz_to_ms_interval(hz);
                     group.occurrence_rate.min = ms;
@@ -451,7 +467,7 @@ pub fn set(
             match edge {
                 widget::range_slider::Edge::Start => {
                     group.simultaneous_sounds.min = num;
-                },
+                }
                 widget::range_slider::Edge::End => {
                     group.simultaneous_sounds.max = num;
                 }

--- a/src/lib/gui/theme.rs
+++ b/src/lib/gui/theme.rs
@@ -1,14 +1,16 @@
-use nannou::ui::{self, widget};
-use nannou::ui::theme::WidgetDefault;
+use conrod_core as ui;
+use conrod_core::{position, Range, Scalar};
+use nannou_conrod::theme::WidgetDefault;
+use nannou_conrod::{self, widget};
 use std;
 
 /// The default width for a widget within a column.
-pub const DEFAULT_WIDTH: ui::Scalar = 220.0;
+pub const DEFAULT_WIDTH: Scalar = 220.0;
 
-fn common_style(w: ui::Scalar, h: ui::Scalar) -> widget::CommonStyle {
+fn common_style(w: ui::Scalar, h: Scalar) -> widget::CommonStyle {
     widget::CommonStyle {
-        maybe_x_dimension: Some(ui::position::Dimension::Absolute(w)),
-        maybe_y_dimension: Some(ui::position::Dimension::Absolute(h)),
+        maybe_x_dimension: Some(position::Dimension::Absolute(w)),
+        maybe_y_dimension: Some(position::Dimension::Absolute(h)),
         ..widget::CommonStyle::default()
     }
 }
@@ -24,9 +26,9 @@ where
 pub fn construct() -> ui::Theme {
     ui::Theme {
         name: "Monochroma".to_owned(),
-        padding: ui::position::Padding {
-            x: ui::Range::new(20.0, 20.0),
-            y: ui::Range::new(20.0, 20.0),
+        padding: position::Padding {
+            x: Range::new(20.0, 20.0),
+            y: Range::new(20.0, 20.0),
         },
         background_color: ui::color::DARK_CHARCOAL,
         shape_color: ui::color::BLACK,

--- a/src/lib/installation.rs
+++ b/src/lib/installation.rs
@@ -4,9 +4,9 @@
 //! hard-coded and rather identified via dynamically generated unique IDs. Otherwise, most
 //! of the logic should remain the same.
 
-use serde::{Deserialize, Deserializer};
+use crate::utils::Range;
+use serde::{Deserialize, Deserializer, Serialize};
 use slug::slugify;
-use utils::Range;
 
 /// All known beyond perception installations (used by default).
 pub const BEYOND_PERCEPTION_NAMES: &'static [&'static str] = &[
@@ -53,8 +53,11 @@ impl<'de> Deserialize<'de> for Id {
             serde_json::Value::Number(n) => {
                 let u = n.as_u64().expect("could not deserialize Id number to u64") as usize;
                 Ok(Id(u))
-            },
-            err => panic!("failed to deserialize `Id`: expected String or Int, found {:?}", err),
+            }
+            err => panic!(
+                "failed to deserialize `Id`: expected String or Int, found {:?}",
+                err
+            ),
         }
     }
 }
@@ -81,7 +84,11 @@ impl Default for Installation {
         let name = default::name().into();
         let computers = Default::default();
         let soundscape = Default::default();
-        Installation { name, computers, soundscape }
+        Installation {
+            name,
+            computers,
+            soundscape,
+        }
     }
 }
 
@@ -95,7 +102,9 @@ pub struct Soundscape {
 impl Default for Soundscape {
     fn default() -> Self {
         let simultaneous_sounds = default::SIMULTANEOUS_SOUNDS;
-        Soundscape { simultaneous_sounds }
+        Soundscape {
+            simultaneous_sounds,
+        }
     }
 }
 
@@ -123,7 +132,7 @@ pub fn beyond_perception_default_num_computers(name: &str) -> Option<usize> {
 
 /// Default soundscape constraints.
 pub mod default {
-    use utils::Range;
+    use crate::utils::Range;
 
     pub const SIMULTANEOUS_SOUNDS: Range<usize> = Range { min: 1, max: 8 };
 
@@ -143,6 +152,7 @@ pub mod default {
 /// State related to the computers available to an installation.
 pub mod computer {
     use fxhash::FxHashMap;
+    use serde::{Deserialize, Serialize};
     use std::net;
 
     /// A unique identifier for a single computer within an installation.

--- a/src/lib/master.rs
+++ b/src/lib/master.rs
@@ -1,6 +1,7 @@
-use audio;
+use crate::audio;
+use crate::metres::Metres;
+use serde::{Deserialize, Serialize};
 use time_calc::Ms;
-use metres::Metres;
 
 /// Master state of the project.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -27,8 +28,12 @@ impl Default for Master {
         let realtime_source_latency = default_realtime_source_latency();
         let dbap_rolloff_db = default_dbap_rolloff_db();
         let proximity_limit_2 = default_proximity_limit();
-        Master { volume, realtime_source_latency, 
-            dbap_rolloff_db, proximity_limit_2 }
+        Master {
+            volume,
+            realtime_source_latency,
+            dbap_rolloff_db,
+            proximity_limit_2,
+        }
     }
 }
 

--- a/src/lib/metres.rs
+++ b/src/lib/metres.rs
@@ -1,20 +1,12 @@
-custom_derive! {
-    /// Used for describing locations throughout the installation.
-    ///
-    /// Using this GUI agnostic measurement greatly simplifies positioning and makes it easier
-    #[derive(Copy, Clone, Debug, Default, PartialEq, PartialOrd,
-             NewtypeFrom,
-             NewtypeAdd, NewtypeSub, NewtypeMul, NewtypeMul(f64), NewtypeDiv, NewtypeDiv(f64),
-             NewtypeAddAssign, NewtypeSubAssign, NewtypeMulAssign, NewtypeDivAssign,
-             NewtypeMulAssign(f64), NewtypeDivAssign(f64),
-             NewtypeRem, NewtypeRemAssign,
-             NewtypeNeg)]
-    #[derive(Serialize, Deserialize)]
-    pub struct Metres(pub f64);
+pub type Metres = f64; //(pub f64);
+
+pub trait Metric {
+    fn min(self: Self, other: Self) -> Self;
+    fn max(self: Self, other: Self) -> Self;
 }
 
-impl Metres {
-    pub fn min(self, other: Self) -> Self {
+impl Metric for Metres {
+    fn min(self, other: Self) -> Self {
         if other < self {
             other
         } else {
@@ -22,7 +14,7 @@ impl Metres {
         }
     }
 
-    pub fn max(self, other: Self) -> Self {
+    fn max(self, other: Self) -> Self {
         if other > self {
             other
         } else {

--- a/src/lib/osc/output.rs
+++ b/src/lib/osc/output.rs
@@ -125,9 +125,10 @@ fn run(msg_rx: Rx, log_tx: mpsc::Sender<Log>) {
     std::thread::Builder::new()
         .name("osc_output_msg_to_update".into())
         .spawn(move || loop {
-            let msg = msg_rx.pop().unwrap();
-            if update_tx.send(Update::Msg(msg)).is_err() {
-                break;
+            if let Some(msg) = msg_rx.pop() {
+                if update_tx.send(Update::Msg(msg)).is_err() {
+                    break;
+                }
             }
         })
         .unwrap();

--- a/src/lib/osc/output.rs
+++ b/src/lib/osc/output.rs
@@ -1,13 +1,12 @@
-use crossbeam::sync::MsQueue;
+use crate::installation;
+use crossbeam::queue::SegQueue;
 use fxhash::FxHashMap;
-use installation;
 use nannou_osc as osc;
 use nannou_osc::Type::{Float, Int};
-use std;
 use std::iter::once;
 use std::sync::{mpsc, Arc};
 
-pub type MessageQueue = Arc<MsQueue<Message>>;
+pub type MessageQueue = Arc<SegQueue<Message>>;
 pub type Tx = MessageQueue;
 type Rx = MessageQueue;
 
@@ -79,7 +78,7 @@ pub struct Log {
 
 /// Spawn the osc sender thread.
 pub fn spawn() -> (std::thread::JoinHandle<()>, Tx, mpsc::Receiver<Log>) {
-    let msg_queue = Arc::new(MsQueue::new());
+    let msg_queue = Arc::new(SegQueue::new());
     let msg_tx = msg_queue.clone();
     let msg_rx = msg_queue;
     let (log_tx, log_rx) = mpsc::channel();
@@ -125,12 +124,10 @@ fn run(msg_rx: Rx, log_tx: mpsc::Sender<Log>) {
     // Start a thread for converting `Message`s to `Update`s.
     std::thread::Builder::new()
         .name("osc_output_msg_to_update".into())
-        .spawn(move || {
-            loop {
-                let msg = msg_rx.pop();
-                if update_tx.send(Update::Msg(msg)).is_err() {
-                    break;
-                }
+        .spawn(move || loop {
+            let msg = msg_rx.pop().unwrap();
+            if update_tx.send(Update::Msg(msg)).is_err() {
+                break;
             }
         })
         .unwrap();
@@ -146,7 +143,7 @@ fn run(msg_rx: Rx, log_tx: mpsc::Sender<Log>) {
                     last_received.clear();
                     last_sent.clear();
                     osc_txs.clear();
-                },
+                }
                 // Audio data received that is to be delivered to the given installation.
                 Message::Audio(installation, data) => {
                     last_received.insert(installation, data);
@@ -166,7 +163,7 @@ fn run(msg_rx: Rx, log_tx: mpsc::Sender<Log>) {
                                     // If we couldn't find the exising socket, we skip it.
                                     None => continue,
                                 }
-                            },
+                            }
                         };
                         osc_txs
                             .entry(installation_id)
@@ -191,81 +188,83 @@ fn run(msg_rx: Rx, log_tx: mpsc::Sender<Log>) {
                 },
             },
 
-            Update::SendOsc => for (installation, data) in last_received.drain() {
-                let AudioFrameData {
-                    avg_peak,
-                    avg_rms,
-                    avg_fft,
-                    speakers,
-                } = data;
+            Update::SendOsc => {
+                for (installation, data) in last_received.drain() {
+                    let AudioFrameData {
+                        avg_peak,
+                        avg_rms,
+                        avg_fft,
+                        speakers,
+                    } = data;
 
-                let targets = match osc_txs.get(&installation) {
-                    Some(targets) => targets,
-                    None => continue,
-                };
-
-                // The buffer used to collect arguments.
-                let mut args = Vec::new();
-
-                // Push the analysis of the averaged channels.
-                args.push(Float(avg_peak));
-                args.push(Float(avg_rms));
-                let lmh = avg_fft.lmh.iter().map(|&f| Float(f));
-                args.extend(lmh);
-                let bins = avg_fft.bins.iter().map(|&f| Float(f));
-                args.extend(bins);
-
-                // Push the Peak and RMS per speaker.
-                let speakers = speakers.into_iter().enumerate().flat_map(|(i, s)| {
-                    once(Int(i as _))
-                        .chain(once(Float(s.peak)))
-                        .chain(once(Float(s.rms)))
-                });
-                args.extend(speakers);
-
-                // Retrieve the OSC sender for each computer in the installation.
-                for target in targets.iter() {
-                    let (
-                        &computer,
-                        &Target {
-                            ref osc_tx,
-                            ref osc_addr,
-                        },
-                    ) = target;
-                    let addr = &osc_addr[..];
-
-                    // Send the message!
-                    let msg = osc::Message {
-                        addr: addr.into(),
-                        args: Some(args.clone()),
+                    let targets = match osc_txs.get(&installation) {
+                        Some(targets) => targets,
+                        None => continue,
                     };
 
-                    // If the message is the same as the last one we sent for this computer, don't
-                    // bother sending it again.
-                    if last_sent.get(&(installation, computer)) == Some(&msg) {
-                        continue;
+                    // The buffer used to collect arguments.
+                    let mut args = Vec::new();
+
+                    // Push the analysis of the averaged channels.
+                    args.push(Float(avg_peak));
+                    args.push(Float(avg_rms));
+                    let lmh = avg_fft.lmh.iter().map(|&f| Float(f));
+                    args.extend(lmh);
+                    let bins = avg_fft.bins.iter().map(|&f| Float(f));
+                    args.extend(bins);
+
+                    // Push the Peak and RMS per speaker.
+                    let speakers = speakers.into_iter().enumerate().flat_map(|(i, s)| {
+                        once(Int(i as _))
+                            .chain(once(Float(s.peak)))
+                            .chain(once(Float(s.rms)))
+                    });
+                    args.extend(speakers);
+
+                    // Retrieve the OSC sender for each computer in the installation.
+                    for target in targets.iter() {
+                        let (
+                            &computer,
+                            &Target {
+                                ref osc_tx,
+                                ref osc_addr,
+                            },
+                        ) = target;
+                        let addr = &osc_addr[..];
+
+                        // Send the message!
+                        let msg = osc::Message {
+                            addr: addr.into(),
+                            args: Some(args.clone()),
+                        };
+
+                        // If the message is the same as the last one we sent for this computer, don't
+                        // bother sending it again.
+                        if last_sent.get(&(installation, computer)) == Some(&msg) {
+                            continue;
+                        }
+
+                        // Send the OSC.
+                        let error = osc_tx.send(msg.clone()).err();
+
+                        // Update the `last_sent` map if there were no errors.
+                        if error.is_none() {
+                            last_sent.insert((installation, computer), msg.clone());
+                        }
+
+                        // Log the message for displaying in the GUI.
+                        let addr = osc_tx.remote_addr();
+                        let log = Log {
+                            installation,
+                            computer,
+                            addr,
+                            msg,
+                            error,
+                        };
+                        log_tx.send(log).ok();
                     }
-
-                    // Send the OSC.
-                    let error = osc_tx.send(msg.clone()).err();
-
-                    // Update the `last_sent` map if there were no errors.
-                    if error.is_none() {
-                        last_sent.insert((installation, computer), msg.clone());
-                    }
-
-                    // Log the message for displaying in the GUI.
-                    let addr = osc_tx.remote_addr();
-                    let log = Log {
-                        installation,
-                        computer,
-                        addr,
-                        msg,
-                        error,
-                    };
-                    log_tx.send(log).ok();
                 }
-            },
+            }
         }
     }
 }

--- a/src/lib/project/config.rs
+++ b/src/lib/project/config.rs
@@ -1,5 +1,7 @@
-use metres::Metres;
-use utils::Seed;
+use serde::{Deserialize, Serialize};
+
+use crate::metres::Metres;
+use crate::utils::Seed;
 
 /// Various configuration parameters for a single project.
 #[derive(Copy, Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -62,8 +64,8 @@ impl Default for Config {
 
 // Fallback parameters in the case that they are missing from the file or invalid.
 pub mod default {
-    use metres::Metres;
-    use utils::Seed;
+    use crate::metres::Metres;
+    use crate::utils::Seed;
 
     pub fn window_width() -> u32 {
         1280
@@ -87,10 +89,10 @@ pub mod default {
         148.0
     }
     pub fn min_speaker_radius_metres() -> Metres {
-        Metres(0.25)
+        0.25
     }
     pub fn max_speaker_radius_metres() -> Metres {
-        Metres(1.0)
+        1.0
     }
 
     pub fn seed() -> Seed {
@@ -98,6 +100,6 @@ pub mod default {
     }
 
     pub fn proximity_limit() -> Metres {
-        ::audio::DEFAULT_PROXIMITY_LIMIT_2
+        crate::audio::DEFAULT_PROXIMITY_LIMIT_2
     }
 }

--- a/src/lib/soundscape/group.rs
+++ b/src/lib/soundscape/group.rs
@@ -2,8 +2,9 @@
 //!
 //! Soundscape groups allow for describing rules/constraints for multiple sounds at once.
 
+use crate::utils::Range;
+use serde::{Deserialize, Serialize};
 use time_calc::Ms;
-use utils::Range;
 
 /// A name for a soundscape group.
 #[derive(Clone, Debug, Eq, PartialOrd, Ord, PartialEq, Hash, Deserialize, Serialize)]
@@ -21,8 +22,8 @@ pub struct Group {
 }
 
 pub mod default {
+    use crate::utils::{Range, HR_MS};
     use time_calc::Ms;
-    use utils::{Range, HR_MS};
     pub const OCCURRENCE_RATE: Range<Ms> = Range {
         min: Ms(0.0),
         max: Ms(HR_MS as _),

--- a/src/lib/soundscape/mod.rs
+++ b/src/lib/soundscape/mod.rs
@@ -672,7 +672,7 @@ pub fn spawn(
     frame_count: Arc<AtomicUsize>,
     seed: Seed,
     tx: mpsc::Sender<Message>,
-    rx: mpsc::Receiver<Message>,
+    _rx: mpsc::Receiver<Message>,
     wav_reader: audio::source::wav::reader::Handle,
     audio_input_stream: audio::input::Stream,
     audio_output_stream: audio::output::Stream,
@@ -726,7 +726,7 @@ pub fn spawn(
     let active_sounds_per_installation = Default::default();
     let available_groups = Default::default();
     let available_sources = Default::default();
-    let model = Model {
+    let _model = Model {
         frame_count,
         realtime_source_latency,
         seed,

--- a/src/lib/soundscape/movement/mod.rs
+++ b/src/lib/soundscape/movement/mod.rs
@@ -1,12 +1,13 @@
-use audio;
-use metres::Metres;
-use nannou::prelude::*;
+use crate::audio;
+use crate::metres::Metres;
 
 pub use self::agent::Agent;
 pub use self::ngon::Ngon;
 
 pub mod agent;
 pub mod ngon;
+
+type Point2 = nannou::glam::DVec2;
 
 /// Whether the sound has fixed movement or generative movement.
 #[derive(Debug)]
@@ -39,7 +40,7 @@ pub struct BoundingRect {
 #[derive(Copy, Clone, Debug)]
 pub struct Area {
     pub bounding_rect: BoundingRect,
-    pub centroid: Point2<Metres>,
+    pub centroid: Point2,
 }
 
 impl Generative {
@@ -64,7 +65,7 @@ impl Movement {
 
 impl BoundingRect {
     /// Initialise a bounding box at a single point in space.
-    pub fn from_point(p: Point2<Metres>) -> Self {
+    pub fn from_point(p: Point2) -> Self {
         BoundingRect {
             left: p.x,
             right: p.x,
@@ -76,7 +77,7 @@ impl BoundingRect {
     /// Determine the movement area bounds on the given set of points.
     pub fn from_points<I>(points: I) -> Option<Self>
     where
-        I: IntoIterator<Item = Point2<Metres>>,
+        I: IntoIterator<Item = Point2>,
     {
         let mut points = points.into_iter();
         points.next().map(|p| {
@@ -86,7 +87,7 @@ impl BoundingRect {
     }
 
     /// Extend the bounding box to include the given point.
-    pub fn with_point(self, p: Point2<Metres>) -> Self {
+    pub fn with_point(self, p: Point2) -> Self {
         BoundingRect {
             left: p.x.min(self.left),
             right: p.x.max(self.right),
@@ -96,12 +97,12 @@ impl BoundingRect {
     }
 
     /// The middle of the bounding box.
-    pub fn middle(&self) -> Point2<Metres> {
+    pub fn middle(&self) -> Point2 {
         let width = self.width();
         let height = self.height();
         let x = self.left + width * 0.5;
         let y = self.bottom + height * 0.5;
-        Point2 { x, y }
+        Point2::new(x, y)
     }
 
     pub fn width(&self) -> Metres {

--- a/src/lib/utils.rs
+++ b/src/lib/utils.rs
@@ -1,12 +1,12 @@
 use nannou::math::map_range;
 use nannou::math::num_traits::{Float, NumCast};
-use serde;
+use serde::{self, Deserialize, Serialize};
 use serde_json;
-use std::{cmp, fmt, fs, io};
 use std::error::Error;
 use std::io::Write;
 use std::path::Path;
 use std::time;
+use std::{cmp, fmt, fs, io};
 use time_calc::Ms;
 
 pub const SEC_MS: f64 = 1_000.0;
@@ -339,64 +339,4 @@ where
 {
     let rquot: F = (numer / denom).floor();
     numer - rquot * denom
-}
-
-pub mod pt2 {
-    use metres::Metres;
-    use nannou::geom::Point2;
-
-    /// Maps the given point to some new type over the dimensions.
-    pub fn convert<T, U>(p: Point2<T>) -> Point2<U>
-    where
-        T: Into<U>,
-    {
-        let Point2 { x, y } = p;
-        let x = x.into();
-        let y = y.into();
-        Point2 { x, y }
-    }
-
-    pub fn to_f64<T>(p: Point2<T>) -> Point2<f64>
-    where
-        T: Into<f64>,
-    {
-        convert(p)
-    }
-
-    pub fn to_metres<T>(p: Point2<T>) -> Point2<Metres>
-    where
-        T: Into<Metres>,
-    {
-        convert(p)
-    }
-}
-
-pub mod vt2 {
-    use metres::Metres;
-    use nannou::geom::Vector2;
-
-    /// Maps the given vector to some new type over the dimensions.
-    pub fn convert<T, U>(p: Vector2<T>) -> Vector2<U>
-    where
-        T: Into<U>,
-    {
-        let Vector2 { x, y } = p;
-        let x = x.into();
-        let y = y.into();
-        Vector2 { x, y }
-    }
-
-    pub fn to_f64<T>(v: Vector2<T>) -> Vector2<f64>
-    where
-        T: Into<f64>,
-    {
-        convert(v)
-    }
-
-    pub fn to_metres<T>(v: Vector2<T>) -> Vector2<Metres>
-    where
-        T: Into<Metres>,
-    {
-        convert(v)
-    }
 }


### PR DESCRIPTION
Trying to get this project to compile in 2022.

I had some issues with the `Cargo.lock` file missing which caused some dependencies to not work out of the box so I updated everything to the latest versions.

This upgrade caused a few issues with generic types, especially `Vector2` and `Point2` which are now using `DVec2` from `glam`.

The main issue in this that I haven't yet worked through is a change in `nannou_audio::stream::Shared<M>` that means in is now `!Sync` as it now contains a `cpal::Stream` which is `!Sync`. I've currently resorted to commenting out starting the Soundscape update thread and it's just returning `None` instead of `Some(thread)` (the instantiation of which is currently commented out so to make the compiler happy)